### PR TITLE
use a pointer to decode volumeconfig

### DIFF
--- a/volumes/volumes.go
+++ b/volumes/volumes.go
@@ -15,7 +15,7 @@ type Volume struct {
 }
 
 func DefaultVolumesFromReader(c config.ConfigReader) (volumes []Volume, err error) {
-	volumeConfig := VolumeConfig{}
+	volumeConfig := &VolumeConfig{}
 	err = c.Read(volumeConfig)
 	return volumeConfig.Volumes, err
 }

--- a/volumes/volumes_test.go
+++ b/volumes/volumes_test.go
@@ -14,7 +14,7 @@ func (f FakeConfigReader) Read(t interface{}) error {
 	return nil
 }
 
-func TestDefaultVolumesFromFile(t *testing.T) {
+func TestDefaultVolumesFromReader(t *testing.T) {
 	fakeVolumeConfig := VolumeConfig{Volumes: []Volume{Volume{HostPath: "/foo", ContainerPath: "/bar", Mode: "RO"}}}
 	reader := &FakeConfigReader{data: fakeVolumeConfig}
 	actual, err := DefaultVolumesFromReader(reader)


### PR DESCRIPTION
this isn't great, because it is making assumptions about the inner
workings of configReader.Read(). But without this, the json encoding
inside the SystemPaaSTAConfigReader fails. I can't quite think of how to
do more right now, given we're using interface{} everywhere.