### PR TITLE
Expand variable names

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,24 +17,24 @@ type SystemPaaSTAConfigFileReader struct {
 	Filename string
 }
 
-func ParseContent(r io.Reader, t interface{}) error {
-	buf, err := ioutil.ReadAll(r)
+func ParseContent(reader io.Reader, content interface{}) error {
+	buf, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return err
 	}
-	err = json.Unmarshal(buf, t)
+	err = json.Unmarshal(buf, content)
 	return err
 }
 
-func (c SystemPaaSTAConfigFileReader) FileNameForConfig() string {
-	return path.Join(c.Basedir, c.Filename)
+func (configReader SystemPaaSTAConfigFileReader) FileNameForConfig() string {
+	return path.Join(configReader.Basedir, configReader.Filename)
 }
 
-func (c SystemPaaSTAConfigFileReader) Read(t interface{}) error {
-	r, err := os.Open(c.FileNameForConfig())
-	defer r.Close()
+func (configReader SystemPaaSTAConfigFileReader) Read(content interface{}) error {
+	reader, err := os.Open(configReader.FileNameForConfig())
+	defer reader.Close()
 	if err != nil {
 		return err
 	}
-	return ParseContent(r, t)
+	return ParseContent(reader, content)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,35 +13,35 @@ type FakeConfig struct {
 }
 
 type fakereader struct {
-	r    io.Reader
-	data *FakeConfig
+	reader io.Reader
+	data   *FakeConfig
 }
 
-func (f fakereader) Read(b []byte) (n int, err error) {
-	return f.r.Read(b)
+func (fakereader fakereader) Read(bytes []byte) (n int, err error) {
+	return fakereader.reader.Read(bytes)
 }
 
-func fakeDataReader(c *FakeConfig) fakereader {
-	content, _ := json.Marshal(*c)
+func fakeDataReader(config *FakeConfig) fakereader {
+	content, _ := json.Marshal(*config)
 	return fakereader{
-		data: c,
-		r:    bytes.NewReader(content),
+		data:   config,
+		reader: bytes.NewReader(content),
 	}
 }
 
-func TestParseContent(t *testing.T) {
+func TestParseContent(test *testing.T) {
 	fakeData := &FakeConfig{}
 	reader := fakeDataReader(fakeData)
 	err := ParseContent(reader, fakeData)
 	if err != nil {
-		t.Errorf("failed to decode content")
+		test.Errorf("failed to decode content")
 	}
 	if !reflect.DeepEqual(reader.data, fakeData) {
-		t.Errorf("deserialized content was incorrect, got: %s, want: %s.", reader.data, fakeData)
+		test.Errorf("deserialized content was incorrect, got: %s, want: %s.", reader.data, fakeData)
 	}
 }
 
-func TestFileNameForConfig(t *testing.T) {
+func TestFileNameForConfig(test *testing.T) {
 	reader := SystemPaaSTAConfigFileReader{
 		Basedir:  "/etc/paasta",
 		Filename: "volumes.json",
@@ -49,6 +49,6 @@ func TestFileNameForConfig(t *testing.T) {
 	expected := "/etc/paasta/volumes.json"
 	actual := reader.FileNameForConfig()
 	if actual != expected {
-		t.Errorf("filename incorrect incorrect, got: %s, want: %s.", actual, expected)
+		test.Errorf("filename incorrect incorrect, got: %s, want: %s.", actual, expected)
 	}
 }

--- a/volumes/volumes.go
+++ b/volumes/volumes.go
@@ -14,8 +14,8 @@ type Volume struct {
 	Mode          string `json:"mode"`
 }
 
-func DefaultVolumesFromReader(c config.ConfigReader) (volumes []Volume, err error) {
+func DefaultVolumesFromReader(configReader config.ConfigReader) (volumes []Volume, err error) {
 	volumeConfig := &VolumeConfig{}
-	err = c.Read(volumeConfig)
+	err = configReader.Read(volumeConfig)
 	return volumeConfig.Volumes, err
 }

--- a/volumes/volumes_test.go
+++ b/volumes/volumes_test.go
@@ -9,19 +9,19 @@ type FakeConfigReader struct {
 	data VolumeConfig
 }
 
-func (f FakeConfigReader) Read(t interface{}) error {
-	t = f.data
+func (fakereader FakeConfigReader) Read(content interface{}) error {
+	content = fakereader.data
 	return nil
 }
 
-func TestDefaultVolumesFromReader(t *testing.T) {
+func TestDefaultVolumesFromReader(test *testing.T) {
 	fakeVolumeConfig := VolumeConfig{Volumes: []Volume{Volume{HostPath: "/foo", ContainerPath: "/bar", Mode: "RO"}}}
 	reader := &FakeConfigReader{data: fakeVolumeConfig}
 	actual, err := DefaultVolumesFromReader(reader)
 	if err != nil {
-		t.Errorf("failed to read config")
+		test.Errorf("failed to read config")
 	}
 	if reflect.DeepEqual(actual, fakeVolumeConfig.Volumes) {
-		t.Errorf("volumes incorrect, got: %s, want: %s.", actual, fakeVolumeConfig.Volumes)
+		test.Errorf("volumes incorrect, got: %s, want: %s.", actual, fakeVolumeConfig.Volumes)
 	}
 }


### PR DESCRIPTION
I know that golang seems to encourage short variable names but I
personally find one letter variable names very hard to parse so I'm
going to be strict that we avoid them.