### PR TITLE
Add deployments package

### DIFF
--- a/deployments/deployments.go
+++ b/deployments/deployments.go
@@ -1,0 +1,94 @@
+// Package deployments provides functions for decoding V2 paasta deployments
+// of the form:
+//   "v2": {
+//    "deployments": {
+//		"everything": {
+//		  "docker_image": "services-fluffy:paasta-abcdfff",
+//		  "git_sha": "abcdfff"
+//		},
+//		"stagef": {
+//		  "docker_image": "services-fluffy:paasta-abcdfff",
+//		  "git_sha": "abcdfff"
+//		}
+//	  },
+//  }
+package deployments
+
+import (
+	"fmt"
+
+	paastaconfig "github.com/Yelp/paasta-tools-go/config"
+)
+
+// V2DeploymentGroup ...
+type V2DeploymentGroup struct {
+	DockerImage string `json:"docker_image"`
+	GitSHA      string `json:"git_sha"`
+}
+
+// V2DeploymentsConfig ...
+type V2DeploymentsConfig struct {
+	Deployments map[string]V2DeploymentGroup `json:"deployments"`
+}
+
+// Deployments ...
+type Deployments struct {
+	V2 V2DeploymentsConfig `json:"v2"`
+}
+
+// DockerRegistry ...
+type DockerRegistry struct {
+	Registry string `json:"docker_registry"`
+}
+
+func getDockerRegistry() (string, error) {
+	dockerRegistry := &DockerRegistry{}
+	configreader := paastaconfig.SystemPaaSTAConfigFileReader{
+		Basedir:  fmt.Sprintf("/etc/paasta"),
+		Filename: "docker_registry.json",
+	}
+	err := configreader.Read(dockerRegistry)
+	return dockerRegistry.Registry, err
+
+}
+
+// DockerImageURLForService returns pullable docker image URL
+// for service given a deployment.
+func DockerImageURLForService(serviceName, deploymentGroup string) (string, error) {
+	var image string
+	configReader := paastaconfig.SystemPaaSTAConfigFileReader{
+		Basedir:  fmt.Sprintf("/nail/etc/services/%s", serviceName),
+		Filename: "deployments.json",
+	}
+	registry, err := getDockerRegistry()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get docker registry")
+	}
+	image, err = getImageURL(configReader, deploymentGroup, registry)
+	if err != nil {
+		return "", fmt.Errorf(
+			"Unable to read from deployments.json for %s",
+			serviceName,
+		)
+	}
+	return image, nil
+}
+
+func getImageURL(cReader paastaconfig.ConfigReader, deploymentGroup, dockerRepo string) (string, error) {
+	deployments := &Deployments{}
+	err := cReader.Read(deployments)
+	if err != nil {
+		return "", err
+	}
+	deployment, ok := deployments.V2.Deployments[deploymentGroup]
+
+	if !ok {
+		return "", fmt.Errorf(
+			"Deployment group %s not found in v2 deployments of %+v",
+			deploymentGroup, deployments,
+		)
+	}
+
+	imageurl := fmt.Sprintf("%s/%s", dockerRepo, deployment.DockerImage)
+	return imageurl, nil
+}

--- a/deployments/deployments_test.go
+++ b/deployments/deployments_test.go
@@ -1,0 +1,63 @@
+package deployments
+
+import (
+	"fmt"
+	"testing"
+
+	paastaconfig "github.com/Yelp/paasta-tools-go/config"
+)
+
+const (
+	dockerRepo = "docker-paasta.yelpcorp.com:443"
+)
+
+type FakeConfigReader struct {
+	data Deployments
+}
+
+func (fakereader FakeConfigReader) Read(content interface{}) error {
+	*content.(*Deployments) = fakereader.data
+	return nil
+}
+
+func TestGetImageURL(test *testing.T) {
+	fakeDeployments := Deployments{
+		V2: V2DeploymentsConfig{
+			Deployments: map[string]V2DeploymentGroup{
+				"dev.every": V2DeploymentGroup{
+					DockerImage: "busybox:latest",
+					GitSHA:      "03d6f783c99695af0e716588abb9ba83ac957be2",
+				},
+				"test.every": V2DeploymentGroup{
+					DockerImage: "ubuntu:latest",
+					GitSHA:      "f3d6f783c99695af0e716588abb9ba83ac957be3",
+				},
+			},
+		},
+	}
+	reader := &FakeConfigReader{data: fakeDeployments}
+	testcases := map[string]string{
+		"dev.every":  "busybox:latest",
+		"test.every": "ubuntu:latest",
+		"absent":     "",
+	}
+	var expected string
+	for dment, imageurl := range testcases {
+		actual, _ := getImageURL(reader, dment, dockerRepo)
+		if imageurl != "" {
+			expected = fmt.Sprintf("%s/%s", dockerRepo, imageurl)
+		} else {
+			expected = ""
+		}
+		if actual != expected {
+			test.Errorf("Failed for %s %s, expected %s", dment, actual, expected)
+		}
+	}
+}
+
+func TestGetImageURLEmptyReader(test *testing.T) {
+	actual, err := getImageURL(paastaconfig.SystemPaaSTAConfigFileReader{}, "", dockerRepo)
+	if err == nil || actual != "" {
+		test.Errorf("Expected to fail for nil interface")
+	}
+}


### PR DESCRIPTION
The package provides  DockerImageURLForService for obtaining a
docker image url when a service name and a deployment group have been
provided.