### PR TITLE
Add hashing module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ branches:
     - /^travis-.*$/
 language: go
 go:
-  - 1.11
+  - 1.11.4

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
 	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,18 @@
 module github.com/Yelp/paasta-tools-go
 
 require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/fatih/structs v1.1.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
 	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 // indirect
 	golang.org/x/text v0.3.0 // indirect
 	golang.org/x/tools v0.0.0-20190130015043-a06a922acc1b // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20190202010724-74b699b93c15
-	k8s.io/apimachinery v0.0.0-20190216013122-f05b8decd79c // indirect
+	k8s.io/apimachinery v0.0.0-20190216013122-f05b8decd79c
 	k8s.io/klog v0.2.0 // indirect
+	k8s.io/kubernetes v1.14.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,19 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 h1:rJm0LuqUjoDhSk2zO9ISMSToQxGz7Os2jRiOL8AWu4c=
 golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 h1:ulvT7fqt0yHWzpJwI57MezWnYDVpCAYBVuYst/L+fAY=
@@ -25,3 +35,5 @@ k8s.io/apimachinery v0.0.0-20190216013122-f05b8decd79c h1:02KEBFny6M5VWKj6Y8Ns27
 k8s.io/apimachinery v0.0.0-20190216013122-f05b8decd79c/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+k8s.io/kubernetes v1.14.0 h1:6T2iAEoOYQnzQb3WvPlUkcczEEXZ7+YPlAO8olwujRw=
+k8s.io/kubernetes v1.14.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeq
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/hashing/hashing.go
+++ b/hashing/hashing.go
@@ -1,0 +1,55 @@
+package hashing
+
+import (
+	"fmt"
+	"github.com/fatih/structs"
+	"hash/fnv"
+	"k8s.io/apimachinery/pkg/util/rand"
+	hashutil "k8s.io/kubernetes/pkg/util/hash"
+	"reflect"
+	"strings"
+)
+
+func ComputeHashForKubernetesObject(object interface{}) (string, error) {
+	value := reflect.ValueOf(object)
+	var objectMeta reflect.Value
+	if value.Kind() == reflect.Ptr {
+		objectMeta = value.Elem().FieldByName("ObjectMeta")
+	} else if value.Kind() == reflect.Struct {
+		objectMeta = value.FieldByName("ObjectMeta")
+	} else {
+		return "", fmt.Errorf("Must pass Kubernetes Object or pointer to Kubernetes Objcect")
+	}
+	// recreate the labels map so we can pass it to the
+	// DeepHashObject function
+	labelsToHash := make(map[string]string)
+	if objectMeta.Kind() == reflect.Struct {
+		labels := objectMeta.FieldByName("Labels")
+		if labels.Kind() == reflect.Map {
+			// equivalent of delete(labels, "yelp.com/operator_config_hash")
+			// we remove this so that the already hashed versions will match
+			// the newly calculated versions
+			labels.SetMapIndex(reflect.ValueOf("yelp.com/operator_config_hash"), reflect.Value{})
+			for _, k := range labels.MapKeys() {
+				v := labels.MapIndex(k)
+				labelsToHash[k.Interface().(string)] = v.Interface().(string)
+			}
+
+		}
+	}
+	// handy library to turn any struct into map[string]interface{}
+	// so we can easily get the SomethingSpec
+	mapOfObject := structs.Map(object)
+	mapToHash := make(map[string]interface{})
+	mapToHash["Labels"] = labelsToHash
+	for k, v := range mapOfObject {
+		// we match on Spec suffix since we don't know if this has
+		// DeploymentSpec PodSpec StatefulSetSpec...
+		if strings.HasSuffix(k, "Spec") {
+			mapToHash["Spec"] = v
+		}
+	}
+	hasher := fnv.New32a()
+	hashutil.DeepHashObject(hasher, mapToHash)
+	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32())), nil
+}

--- a/hashing/hashing_test.go
+++ b/hashing/hashing_test.go
@@ -1,0 +1,115 @@
+package hashing
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestGetHashForKubernetesObject(t *testing.T) {
+	labels := map[string]string{
+		"yelp.com/rick": "andmortyadventures",
+	}
+	replicas := int32(2)
+	someStatefulSet := &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "StatefulSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "morty-test-cluster",
+			Namespace: "paasta-cassandra",
+			Labels:    labels,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{corev1.PersistentVolumeClaim{}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Volumes:    []corev1.Volume{},
+					Containers: []corev1.Container{},
+				},
+			},
+		},
+	}
+	hash, err := ComputeHashForKubernetesObject(someStatefulSet)
+	if err != nil {
+		t.Errorf("Failed to calculate hash")
+	}
+	assert.Equal(t, hash, "f968dcd9f")
+
+	// to test that a new pointer to a semantically matching object has the same hash
+	theSameReplicas := int32(2)
+	theSameStatefulSet := &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "StatefulSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "morty-test-cluster",
+			Namespace: "paasta-cassandra",
+			Labels:    labels,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &theSameReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{corev1.PersistentVolumeClaim{}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Volumes:    []corev1.Volume{},
+					Containers: []corev1.Container{},
+				},
+			},
+		},
+	}
+	anotherHash, err := ComputeHashForKubernetesObject(theSameStatefulSet)
+	if err != nil {
+		t.Errorf("Failed to calculate hash")
+	}
+	assert.Equal(t, anotherHash, "f968dcd9f")
+
+	// test the hash changes if we change replicas
+	replicas = int32(1)
+	someStatefulSet.Spec.Replicas = &replicas
+	hash, err = ComputeHashForKubernetesObject(someStatefulSet)
+	if err != nil {
+		t.Errorf("Failed to calculate hash")
+	}
+	assert.Equal(t, hash, "569c7fc7d4")
+
+	// test hash changes if we change labels
+	someStatefulSet.ObjectMeta.Labels["yelp.com/for"] = "everandever"
+	hash, err = ComputeHashForKubernetesObject(someStatefulSet)
+	if err != nil {
+		t.Errorf("Failed to calculate hash")
+	}
+	assert.Equal(t, hash, "85445d55bb")
+
+	// test hash ignores yelp.com/operator_config_hash label
+	someStatefulSet.ObjectMeta.Labels["yelp.com/operator_config_hash"] = "somehash"
+	hash, err = ComputeHashForKubernetesObject(someStatefulSet)
+	if err != nil {
+		t.Errorf("Failed to calculate hash")
+	}
+	assert.Equal(t, hash, "85445d55bb")
+
+	// test we get same hash if we pass the actual struct not a pointer
+	hash, err = ComputeHashForKubernetesObject(*someStatefulSet)
+	if err != nil {
+		t.Errorf("Failed to calculate hash")
+	}
+	assert.Equal(t, hash, "85445d55bb")
+}


### PR DESCRIPTION
This adds two functions. One that takes a pointer to an arbitrary
Kubernetes object and returns a hash of that object that can then be
assigned to a label. The other retrieves said hash from the label.