### PR TITLE
Implement make target for building a deb with tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .*.swp
+dist
+bin

--- a/yelp_package/xenial/Dockerfile
+++ b/yelp_package/xenial/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:xenial
+
+ARG GO_VERSION
+
+RUN apt-get -q update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -q install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        wget \
+        ruby \ 
+        ruby-dev \ 
+        rubygems \
+        build-essential \
+    && apt-get -q clean
+
+# Install go
+RUN wget http://godeb.s3.amazonaws.com/godeb-amd64.tar.gz && \
+    tar zxvf godeb-amd64.tar.gz && \
+    ./godeb download ${GO_VERSION} && \
+    dpkg -i go_${GO_VERSION}-godeb1_amd64.deb && \
+    rm godeb-amd64.tar.gz godeb go_${GO_VERSION}-godeb1_amd64.deb
+
+RUN gem install --no-ri --no-rdoc fpm
+
+WORKDIR /work


### PR DESCRIPTION
The idea is to build each package under `tools/` into a separate binary and then put them into a deb. 

My main issue with dpkg-buildpackage and dh_golang was that I couldn't find a way to change the names of the binaries it produced, they were just the bare name of the package, e.g. `draining`. The package also included the source, which didn't seem necessary.