### PR TITLE
refactor code to retrieve image

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,7 +12,7 @@ type ConfigReader interface {
 	Read(interface{}) error
 }
 
-type SystemPaaSTAConfigFileReader struct {
+type ConfigFileReader struct {
 	Basedir  string
 	Filename string
 }
@@ -26,11 +26,11 @@ func ParseContent(reader io.Reader, content interface{}) error {
 	return err
 }
 
-func (configReader SystemPaaSTAConfigFileReader) FileNameForConfig() string {
+func (configReader ConfigFileReader) FileNameForConfig() string {
 	return path.Join(configReader.Basedir, configReader.Filename)
 }
 
-func (configReader SystemPaaSTAConfigFileReader) Read(content interface{}) error {
+func (configReader ConfigFileReader) Read(content interface{}) error {
 	reader, err := os.Open(configReader.FileNameForConfig())
 	defer reader.Close()
 	if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -42,7 +42,7 @@ func TestParseContent(test *testing.T) {
 }
 
 func TestFileNameForConfig(test *testing.T) {
-	reader := SystemPaaSTAConfigFileReader{
+	reader := ConfigFileReader{
 		Basedir:  "/etc/paasta",
 		Filename: "volumes.json",
 	}


### PR DESCRIPTION
- rename SystemPaaSTAConfigFileReader to ConfigFileReader, since it is generic
- create pluggable interfaces for reading docker image urls so we can create some mock interfaces for testing