### PR TITLE
Add paasta binary that calls paasta- subcommands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ docker_build_%:
 deb_%: clean docker_build_%
 	$(DOCKER_RUN) /bin/bash -c ' \
 		$(MAKE) cmd && \
+		mv bin/paasta{-tools-paasta,_go} && \
 		fpm --output-type deb --input-type dir --version $(VERSION) \
 			--deb-dist $* --deb-priority optional \
 			--name paasta-tools-go --package dist \

--- a/cmd/paasta/main.go
+++ b/cmd/paasta/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	if cmdPath == "" {
-		cmdPath = "/usr/bin/paasta"
+		cmdPath = "/opt/venvs/paasta-tools/bin/paasta"
 		args = os.Args
 	} else {
 		args = os.Args[1:]

--- a/cmd/paasta/main.go
+++ b/cmd/paasta/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func listPaastaCommands() (map[string]bool, error) {
+	// alternatively:
+	// find $(echo $PATH | tr ':' ' ') -maxdepth 1 -xtype f -perm /o+x -name paasta-*
+	cmd := exec.Command("/bin/bash", "-p", "-c", "compgen -A command paasta-")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	cmds := map[string]bool{}
+	for scanner.Scan() {
+		cmds[scanner.Text()] = true
+	}
+	return cmds, nil
+}
+
+func main() {
+	var cmds map[string]bool = nil
+	var subcmd string
+	var args []string
+
+	if len(os.Args) > 1 {
+		var err error
+		cmds, err = listPaastaCommands()
+		if err != nil {
+			fmt.Printf("Error generating list of sub-commands: %s\n", err)
+			os.Exit(1)
+		}
+
+		cmd := fmt.Sprintf("paasta-%s", os.Args[1])
+		if ok, _ := cmds[cmd]; ok {
+			var err error
+			subcmd, err = exec.LookPath(cmd)
+			if err != nil {
+				fmt.Printf("Couldn't lookup %s in PATH: %s\n", cmd, err)
+				os.Exit(1)
+			}
+		}
+	}
+
+	if subcmd == "" {
+		subcmd = "/usr/bin/paasta"
+		args = os.Args
+	} else {
+		args = os.Args[1:]
+	}
+
+	if err := syscall.Exec(subcmd, args, os.Environ()); err != nil {
+		fmt.Printf("Error running %s: %s", subcmd, err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 	k8s.io/kubernetes v1.14.0
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
This is a proof-of-concept replacement for main paasta binary (which is in python) with a stub that calls a sub-command or the original python script. Because calling `paasta true` when having `paasta-true` symlinked to `/bin/true` is still taking almost a second to run.