### PR TITLE
[PAASTA-16263] Allow for SetKubernetesObjectHash to overwrite old hash labels

### DIFF
--- a/pkg/hashing/hashing.go
+++ b/pkg/hashing/hashing.go
@@ -52,9 +52,7 @@ func ComputeHashForKubernetesObject(object interface{}) (string, error) {
 }
 
 func SetKubernetesObjectHash(configHash string, object interface{}) error {
-	labelsToAdd := map[string]string{
-		"yelp.com/operator_config_hash": configHash,
-	}
+	labelsToAdd := map[string]string{}
 	value := reflect.ValueOf(object)
 	var objectMeta reflect.Value
 	if value.Kind() == reflect.Ptr {
@@ -69,6 +67,8 @@ func SetKubernetesObjectHash(configHash string, object interface{}) error {
 				v := labels.MapIndex(k)
 				labelsToAdd[k.Interface().(string)] = v.Interface().(string)
 			}
+			// Set the configHash label last, so that any prior configHash label is overwritten with the new one
+			labelsToAdd["yelp.com/operator_config_hash"] = configHash
 			labels.Set(reflect.ValueOf(labelsToAdd))
 		}
 	}

--- a/pkg/hashing/hashing_test.go
+++ b/pkg/hashing/hashing_test.go
@@ -154,6 +154,15 @@ func TestSetKubernetesObjectHash(t *testing.T) {
 	assert.NotEqual(t, someStatefulSet.Spec.Template.ObjectMeta.Labels["yelp.com/operator_config_hash"], "abc1234")
 	// but the existing labels are
 	assert.Equal(t, someStatefulSet.Spec.Selector.MatchLabels["yelp.com/rick"], "andmortyadventures")
+
+	// Now let's try updating the object with a new hash
+	err = SetKubernetesObjectHash("def5678", someStatefulSet)
+	if err != nil {
+		t.Errorf("Failed to add label")
+	}
+	// the new hash and existing label are present in ObjectMeta
+	assert.Equal(t, someStatefulSet.ObjectMeta.Labels["yelp.com/operator_config_hash"], "def5678")
+	assert.Equal(t, someStatefulSet.ObjectMeta.Labels["yelp.com/rick"], "andmortyadventures")
 }
 
 func TestMultipleLevels(t *testing.T) {


### PR DESCRIPTION
See https://github.com/Yelp/paasta-tools-go/issues/40 and internal ticket