### PR TITLE
Add cleanup target

### DIFF
--- a/pkg/test_framework/harness.go
+++ b/pkg/test_framework/harness.go
@@ -357,6 +357,7 @@ func checkMakefile(options Options, sinks Sinks) {
 	}
 	check(options.operatorStart())
 	check(options.operatorStop())
+	check(options.cleanup())
 }
 
 type envScanner struct {

--- a/pkg/test_framework/harness_test.go
+++ b/pkg/test_framework/harness_test.go
@@ -121,6 +121,7 @@ echo "tests-cluster-start \$\{RND\}"
 echo "tests-cluster-stop \$\{RND\}"
 echo "tests-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 echo "tests-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "tests-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 $`, cout.String())
 	assert.Empty(t, cerr.String())
 	assert.Empty(t, operator.String())
@@ -158,6 +159,7 @@ func TestCheckNoCleanup(t *testing.T) {
 echo "fail-close-cluster-start \$\{RND\}"
 echo "fail-close-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 echo "fail-close-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "fail-close-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 $`, cout.String())
 	assert.Empty(t, cerr.String())
 	assert.Empty(t, operator.String())
@@ -180,14 +182,15 @@ echo "tests-cluster-start \$\{RND\}"
 echo "tests-cluster-stop \$\{RND\}"
 echo "tests-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 echo "tests-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "tests-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 `
+	err := kube.Close()
+	assert.NoError(t, err)
 	cmp += fmt.Sprintf(`export RND=%s
 tests-cluster-stop %s
 tests-cluster-start %s
 tests-cluster-stop %s
 $`, rnd, rnd, rnd, rnd)
-	err := kube.Close()
-	assert.NoError(t, err)
 	assert.Regexp(t, cmp, cout.String())
 	assert.Empty(t, cerr.String())
 	assert.Empty(t, operator.String())
@@ -212,12 +215,13 @@ func TestStartNoCleanup(t *testing.T) {
 echo "fail-close-cluster-start \$\{RND\}"
 echo "fail-close-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 echo "fail-close-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "fail-close-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 `
+	err := kube.Close()
+	assert.NoError(t, err)
 	cmp += fmt.Sprintf(`export RND=%s
 fail-close-cluster-start %s
 $`, rnd, rnd)
-	err := kube.Close()
-	assert.NoError(t, err)
 	assert.Regexp(t, cmp, cout.String())
 	assert.Empty(t, cerr.String())
 	assert.Empty(t, operator.String())

--- a/pkg/test_framework/make_targets.go
+++ b/pkg/test_framework/make_targets.go
@@ -15,6 +15,7 @@ const (
 	targetClusterStop   = "cluster-stop"
 	targetOperatorStart = "operator-start"
 	targetOperatorStop  = "operator-stop"
+	targetCleanup       = "cleanup"
 )
 
 func (o Options) env() string {
@@ -35,6 +36,10 @@ func (o Options) operatorStart() string {
 
 func (o Options) operatorStop() string {
 	return o.Prefix + targetOperatorStop
+}
+
+func (o Options) cleanup() string {
+	return o.Prefix + targetCleanup
 }
 
 // This interface is used to handle the process after it's been started

--- a/pkg/test_framework/make_targets.go
+++ b/pkg/test_framework/make_targets.go
@@ -95,11 +95,11 @@ func start(handler Handler, outSinks []io.Writer, errSinks []io.Writer, args []s
 		}
 	}()
 
+	wg1.Wait()
 	// We will lose the output of cmd if it is started before Scan() calls in the
 	// go routines above. So let's wait here until they are both scheduled, and
 	// at least 50ms, to give the go scheduler enough time
 	time.Sleep(time.Millisecond * 50)
-	wg1.Wait()
 	err = cmd.Start()
 	if err != nil {
 		return err

--- a/pkg/test_framework/test_test.go
+++ b/pkg/test_framework/test_test.go
@@ -22,13 +22,13 @@ func TestStartQuick(t *testing.T) {
 	_ = os.Unsetenv("RND")
 	kube := startHarness(options, sinks)
 	assert.NotNil(t, kube)
-	test := kube.NewTest(t)
+	test := kube.NewTest(t).Setup()
 	err := test.StartOperator()
 	// error because make tests-operator-start is not blocking
 	assert.NotNil(t, err)
-	_, nset := os.LookupEnv("TEST_OPERATOR_NS")
-	assert.Equal(t,false, nset)
-	test.Close()
+	ns, nset := os.LookupEnv("TEST_OPERATOR_NS")
+	assert.Equal(t,true, nset)
+	assert.Equal(t, test.Namespace, ns)
 
 	rnd, ok := os.LookupEnv("RND")
 	assert.Equal(t, true, ok)
@@ -37,12 +37,15 @@ echo "tests-cluster-start \$\{RND\}"
 echo "tests-cluster-stop \$\{RND\}"
 echo "tests-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 echo "tests-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "tests-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 `
 	cmp += fmt.Sprintf(`export RND=%s
 tests-cluster-stop %s
 tests-cluster-start %s
+tests-cleanup %s %s
 tests-cluster-stop %s
-$`, rnd, rnd, rnd, rnd)
+$`, rnd, rnd, rnd, rnd, ns, rnd)
+	test.Close()
 	err = kube.Close()
 	assert.NoError(t, err)
 	assert.Regexp(t, cmp, cout.String())
@@ -51,7 +54,7 @@ $`, rnd, rnd, rnd, rnd)
 	assert.Empty(t, cerr.String())
 }
 
-func TestStartSlow(t *testing.T) {
+func TestStartSlowNoCleanup(t *testing.T) {
 	options := *newOptions()
 	options.NoCleanup = true
 	options.Prefix = "test-sleep05-"
@@ -64,7 +67,7 @@ func TestStartSlow(t *testing.T) {
 	_ = os.Unsetenv("RND")
 	kube := startHarness(options, sinks)
 	assert.NotNil(t, kube)
-	test := kube.NewTest(t)
+	test := kube.NewTest(t).Setup()
 
 	// this will block long enough to register "operator running"
 	err := test.StartOperator()
@@ -78,7 +81,6 @@ func TestStartSlow(t *testing.T) {
 	ns, nset = os.LookupEnv("TEST_OPERATOR_NS")
 	assert.Equal(t, true, nset)
 	assert.Equal(t, test.Namespace, ns)
-	test.Close()
 
 	rnd, ok := os.LookupEnv("RND")
 	assert.Equal(t, true, ok)
@@ -87,12 +89,63 @@ echo "test-sleep05-cluster-start \$\{RND\}"
 echo "test-sleep05-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 sleep 0\.5s
 echo "test-sleep05-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "test-sleep05-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
 `
 	cmp += fmt.Sprintf(`export RND=%s
 test-sleep05-cluster-start %s
 test-sleep05-operator-stop %s %s
 $`, rnd, rnd, rnd, ns)
-	// intentionally not calling StopOperator(), kube.Close() should call it for us
+	// intentionally not calling StopOperator(), test.Close() should call it for us
+	test.Close()
+	err = kube.Close()
+	assert.NoError(t, err)
+	assert.Regexp(t, cmp, cout.String())
+	// stdout output of the operator goes to the operator sink
+	cmp = fmt.Sprintf("test-sleep05-operator-start %s %s\n", rnd, ns)
+	assert.Equal(t, cmp, operator.String())
+	assert.Empty(t, cerr.String())
+}
+
+func TestStartSlowWithCleanup(t *testing.T) {
+	options := *newOptions()
+	options.Prefix = "test-sleep05-"
+	options.OperatorStartDelay = 200 * time.Millisecond
+	cout := bytes.Buffer{}
+	cerr := bytes.Buffer{}
+	operator := bytes.Buffer{}
+	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
+	// NOTE: buildEnv never overwrites existing env. variable
+	_ = os.Unsetenv("RND")
+	kube := startHarness(options, sinks)
+	assert.NotNil(t, kube)
+	test := kube.NewTest(t).Setup()
+
+	// this will block long enough to register "operator running"
+	err := test.StartOperator()
+	assert.NoError(t, err)
+	ns, nset := os.LookupEnv("TEST_OPERATOR_NS")
+	assert.Equal(t, true, nset)
+	assert.Equal(t, test.Namespace, ns)
+
+	rnd, ok := os.LookupEnv("RND")
+	assert.Equal(t, true, ok)
+	cmp := `^echo "export RND=.*
+echo "test-sleep05-cluster-start \$\{RND\}"
+echo "test-sleep05-cluster-stop \$\{RND\}"
+echo "test-sleep05-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+sleep 0\.5s
+echo "test-sleep05-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "test-sleep05-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+`
+	cmp += fmt.Sprintf(`export RND=%s
+test-sleep05-cluster-stop %s
+test-sleep05-cluster-start %s
+test-sleep05-operator-stop %s %s
+test-sleep05-cleanup %s %s
+test-sleep05-cluster-stop %s
+$`, rnd, rnd, rnd, rnd, ns, rnd, ns, rnd)
+	// intentionally not calling StopOperator(), test.Close() should call it for us
+	test.Close()
 	err = kube.Close()
 	assert.NoError(t, err)
 	assert.Regexp(t, cmp, cout.String())

--- a/pkg/test_framework/tests/Makefile
+++ b/pkg/test_framework/tests/Makefile
@@ -14,6 +14,9 @@ test-sleep05-operator-start:
 %-operator-stop:
 	@echo "$*-operator-stop $${RND} $${TEST_OPERATOR_NS}"
 
+%-cleanup:
+	@echo "$*-cleanup $${RND} $${TEST_OPERATOR_NS}"
+
 %-env:
 	@echo "export RND=$$(xxd -l8 -p /dev/random)"
 


### PR DESCRIPTION
The purpose is to disentangle stopping the operator from post-test cleanup, this way allowing the use of StopOperator() mid-test, possibly followed by StartOperator().

Also updated test_test.go to use Setup() with added defensive check, so it does not try to use k8s inside unit tests (which would result in a SIGSEGV)"