### PR TITLE
Fixing CI errors in pkg/test_framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ branches:
     - /^travis-.*$/
 language: go
 go:
-  - 1.11.4
+  - 1.12.15

--- a/pkg/test_framework/test.go
+++ b/pkg/test_framework/test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -107,9 +108,10 @@ type asynchronousHandler struct {
 // when operatorStartDelay has elapsed.
 // If we have received anything on the channel (before it closed), it means that
 // the program completed; otherwise we consider it running.
-func(h* asynchronousHandler) Handle(cmd *exec.Cmd) {
+func(h* asynchronousHandler) Handle(cmd *exec.Cmd, wg *sync.WaitGroup) {
 	channel := newChanError()
 	go func() {
+		wg.Wait()
 		err := cmd.Wait()
 		// will only succeed to send an error if completed before operatorStartDelay
 		channel.send(err)

--- a/pkg/test_framework/tests/Makefile
+++ b/pkg/test_framework/tests/Makefile
@@ -18,7 +18,7 @@ test-sleep05-operator-start:
 	@echo "$*-cleanup $${RND} $${TEST_OPERATOR_NS}"
 
 %-env:
-	@echo "export RND=$$(xxd -l8 -p /dev/random)"
+	@echo "export RND=$$(xxd -l8 -p /dev/urandom)"
 
 %:
 	@echo "$* $${RND}"


### PR DESCRIPTION
This should finally resolve the CI problems where we finish running the make target before make_targets.go started collecting their output.