### PR TITLE
Refactor and extend the functionality of WaitFor

### DIFF
--- a/pkg/test_framework/helpers.go
+++ b/pkg/test_framework/helpers.go
@@ -152,28 +152,14 @@ func LoadInto(r io.Reader, into interface{}) error {
 
 type WaitForFn func()(interface{}, error)
 
-// Wait until WaitSource returns 0 elements or NotFound error - useful for waiting until
-// something is deleted
-func WaitForNone(timeout time.Duration, from WaitForFn) error {
-	none := int32(0)
-	return WaitFor(&none, timeout, from)
-}
-
 // Wait until from returns a given number of instances. In the context of strongly
 // typed non-List k8s objects this typically means number of ready pods; for List objects
 // (including UnstructuredList) this means number of items; for Unstructured object
 // this means hardcoded 1. For details, refer to getReady function.
-// We use a pointer int32 to allow the use of ...Spec.Replicas; for the same reason we
-// fallback to hardcoded 1 if nil is provided
-func WaitFor(reps* int32, timeout time.Duration, from WaitForFn) error {
-	wanted := int32(1)
-	if reps != nil {
-		wanted = *reps
-	}
-
+func WaitFor(wanted int, timeout time.Duration, from WaitForFn) error {
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 		current, err := from()
-		ready := int32(0)
+		ready := 0
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				return false, err
@@ -192,64 +178,64 @@ func WaitFor(reps* int32, timeout time.Duration, from WaitForFn) error {
 	})
 }
 
-func getReady(obj interface{}) (int32, error) {
+func getReady(obj interface{}) (int, error) {
 	switch t := obj.(type) {
 	case *appsv1.StatefulSet:
-		return (*t).Status.ReadyReplicas, nil
+		return int((*t).Status.ReadyReplicas), nil
 	case *appsv1.Deployment:
-		return (*t).Status.ReadyReplicas, nil
+		return int((*t).Status.ReadyReplicas), nil
 	case *appsv1.DaemonSet:
-		return (*t).Status.NumberReady, nil
+		return int((*t).Status.NumberReady), nil
 	case *appsv1.ReplicaSet:
-		return (*t).Status.ReadyReplicas, nil
+		return int((*t).Status.ReadyReplicas), nil
 	case *batchv1.Job:
-		return (*t).Status.Active, nil
+		return int((*t).Status.Active), nil
 	case *appsv1.StatefulSetList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *appsv1.DeploymentList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *appsv1.DaemonSetList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *appsv1.ReplicaSetList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *appsv1.ControllerRevisionList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *batchv1.JobList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.PersistentVolumeList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.PersistentVolumeClaimList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.PodList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.ServiceList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.ServiceAccountList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.EndpointsList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.NodeList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.NamespaceList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.EventList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.SecretList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.ConfigMapList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *corev1.ComponentStatusList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *rbacv1.RoleBindingList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *rbacv1.RoleList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *rbacv1.ClusterRoleBindingList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *rbacv1.ClusterRoleList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *unstructured.UnstructuredList:
-		return int32(len((*t).Items)), nil
+		return len((*t).Items), nil
 	case *unstructured.Unstructured:
 		if !t.IsList() {
 			// Consider single object an equivalent for a list of 1
@@ -259,13 +245,13 @@ func getReady(obj interface{}) (int32, error) {
 		if err != nil {
 			log.Panic(err)
 		}
-		return int32(len(list.Items)), nil
+		return len(list.Items), nil
 	case int64:
-		return int32(t), nil
+		return int(t), nil
 	case int32:
-		return t, nil
+		return int(t), nil
 	case int:
-		return int32(t),nil
+		return t, nil
 	default:
 		log.Panicf("Unsupported type %t", obj)
 	}

--- a/pkg/test_framework/helpers.go
+++ b/pkg/test_framework/helpers.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,8 +15,10 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Read an element (value or section) from the unstructured object, given a path
@@ -256,4 +259,138 @@ func getReady(obj interface{}) (int, error) {
 		log.Panicf("Unsupported type %t", obj)
 	}
 	return 0, nil
+}
+
+type WaitForResourceFn func(obj unstructured.Unstructured)(int, error)
+
+// Wait for a singular resource like the one provided. Will use APIVersion and Kind from
+// like parameter. If name parameter is provided, will use Name and Namespace from name
+// parameter, otherwise will use Name and Namespace from like as well.
+// Optionally takes a function which can be used to transform a single resource into
+// a number (e.g. acting on some part of the object's spec or status section).
+func WaitForResource(wanted int, timeout time.Duration, client1 client.Client, like runtime.Object, name runtime.Object, fn WaitForResourceFn) error {
+	if name == nil {
+		name = like
+	}
+	apiver, kind := like.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+	objname, objns := getSingularNameNs(name)
+
+	return WaitFor(
+		wanted,
+		timeout,
+		func() (interface{}, error) {
+			res := &unstructured.Unstructured{}
+			res.SetAPIVersion(apiver)
+			res.SetKind(kind)
+			err := client1.Get(context.TODO(), client.ObjectKey{
+				Namespace: objns,
+				Name: objname,
+			}, res)
+			if err != nil {
+				return nil, err
+			}
+			if fn == nil {
+				return res, nil
+			}
+			return fn(*res)
+		},
+	)
+}
+
+type WaitForResourcesFn func(obj unstructured.UnstructuredList)(int, error)
+
+// Wait for a list of resources like the one provided. Will use APIVersion and Kind from
+// like parameter. If name parameter is provided, will use Namespace (only!) from name
+// parameter, otherwise will use Namespace from like as well.
+// Optionally takes a function which can be used to transform the list into
+// a number (e.g. filtering by some part of the objects' name or status).
+//
+// Note: lists of kubernetes resources do not carry a singular Namespace, so if name
+// is nil AND like is a list of objects, you will get a panic from getSingularNameNs.
+// This can be avoided either by passing a name parameter, or by passing a singular
+// (rather than a list) resource to like parameter, with namespace set.
+// Example waiting for a number of pods in someNamespace:
+//   pod := corev1.Pod{}
+//   pod.SetNamespace(someNamespace)
+//   err := WaitForResources(howManyPodsWanted, someTimeout, someClient, pod, nil, nil)
+func WaitForResources(wanted int, timeout time.Duration, client1 client.Client, like runtime.Object, name runtime.Object, fn WaitForResourcesFn) error {
+	if name == nil {
+		name = like
+	}
+	apiver, kind := like.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+	_, objns := getSingularNameNs(name)
+
+	return WaitFor(
+		wanted,
+		timeout,
+		func() (interface{}, error) {
+			res := &unstructured.UnstructuredList{}
+			res.SetAPIVersion(apiver)
+			res.SetKind(kind)
+			err := client1.List(context.TODO(), &client.ListOptions{
+				Namespace: objns,
+			}, res)
+			if err != nil {
+				return nil, err
+			}
+			if fn == nil {
+				return res, nil
+			}
+			return fn(*res)
+		},
+	)
+}
+
+func getSingularNameNs(obj runtime.Object) (string, string) {
+	switch t := obj.(type) {
+	case *appsv1.StatefulSet:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *appsv1.Deployment:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *appsv1.DaemonSet:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *appsv1.ReplicaSet:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *batchv1.Job:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *appsv1.ControllerRevision:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.PersistentVolume:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.PersistentVolumeClaim:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.Pod:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.Service:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.ServiceAccount:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.Endpoints:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.Node:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.Namespace:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.Event:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.Secret:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.ConfigMap:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *corev1.ComponentStatus:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *rbacv1.RoleBinding:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *rbacv1.Role:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *rbacv1.ClusterRoleBinding:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *rbacv1.ClusterRole:
+		return (*t).GetName(), (*t).GetNamespace()
+	case *unstructured.Unstructured:
+		return (*t).GetName(), (*t).GetNamespace()
+	default:
+		log.Panicf("Unsupported type %t", obj)
+	}
+	return "", ""
 }


### PR DESCRIPTION
Note, this is a breaking change because callers of `WaitFor` have to use an `int` and change the signature of the function (lambda) used, to return `interface{}` rather than runtime.Object. I have replaced the `*int32` parameter with a straight `int` and removed `WaitForNone` because the user can now simply write `WaitFor(0, ...)`

The benefit is the simplification of the user code when using this framework - the user function can now return a number (int64, int32 or int - other types are not supported) to indicate the current status of the waited-for condition; and the user can now also use the number directly in the `WaitFor` function call rather than the current "make a number and take its address" workaround for `*int32`. This can be used in practice by an optional user function passed to `WaitForResource`/`WaitForResources` to implement some kind of filtering on `Unstructured` or respectively `UnstructuredList`.

I plan to refactor `WaitFor` further, so this is probably not the last breaking change.