### PR TITLE
Use golang 1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pkg/errors v0.8.1
@@ -33,4 +34,4 @@ require (
 	sigs.k8s.io/controller-runtime v0.1.10
 )
 
-go 1.13
+go 1.12


### PR DESCRIPTION
We actually do not use Go 1.13 just yet in all projects, even though it "happens to work" for this project. Let's be clear that this is a Go 1.12 project (at this time).

While doing so, let's also add a missing dependency.