### PR TITLE
Support CRDs in test client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pkg/errors v0.8.1

--- a/pkg/test_framework/harness.go
+++ b/pkg/test_framework/harness.go
@@ -107,7 +107,7 @@ func Parse() *Options {
 	return &options
 }
 
-func Start(m *testing.M, options Options, sinks Sinks) {
+func Start(options Options, sinks Sinks) {
 	// NOTE: We call "sanitize" functions both here and in Parse() to avoid
 	// strong coupling, i.e. we do not make strong assumption as to the format
 	// of MakeDir and Prefix here, hence allowing the user to skip Parse()

--- a/pkg/test_framework/harness.go
+++ b/pkg/test_framework/harness.go
@@ -24,7 +24,7 @@ type Harness struct {
 	harness.Harness
 	Options Options
 	Sinks   Sinks
-	client  client.Client
+	Client  client.Client
 }
 
 func (h *Harness) Close() error {
@@ -55,13 +55,6 @@ func (h *Harness) OpenManifest(manifest string) (*os.File, error) {
 	}
 
 	return f, nil
-}
-
-func (h *Harness) Client() client.Client {
-	if h.client == nil {
-		log.Panicf("k8s client not initialised")
-	}
-	return h.client
 }
 
 type Options struct {
@@ -121,7 +114,7 @@ func Start(m *testing.M, options Options, sinks Sinks) {
 	options.MakeDir = sanitizeMakeDir(options.MakeDir)
 	options.Prefix = sanitizePrefix(options.Prefix)
 	Kube = startHarness(options, sinks)
-	Kube.client = newClient()
+	Kube.Client = newClient()
 }
 
 // NOTE: this function MUST be idempotent, because it will be called both
@@ -188,7 +181,7 @@ func startHarness(options Options, sinks Sinks) *Harness {
 		Harness: *harness.New(options.Options),
 		Options: options,
 		Sinks:   sinks,
-		client:  nil,
+		Client:  nil,
 	}
 }
 

--- a/pkg/test_framework/harness_test.go
+++ b/pkg/test_framework/harness_test.go
@@ -173,7 +173,7 @@ func TestStart(t *testing.T) {
 	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
 	// NOTE: buildEnv never overwrites existing env. variable
 	_ = os.Unsetenv("RND")
-	kube := startHarness(options, sinks)
+	kube := startHarness(options, sinks, nil)
 	assert.NotNil(t, kube)
 	rnd, ok := os.LookupEnv("RND")
 	assert.Equal(t, true, ok)
@@ -207,7 +207,7 @@ func TestStartNoCleanup(t *testing.T) {
 	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
 	// NOTE: buildEnv never overwrites existing env. variable
 	_ = os.Unsetenv("RND")
-	kube := startHarness(options, sinks)
+	kube := startHarness(options, sinks, nil)
 	assert.NotNil(t, kube)
 	rnd, ok := os.LookupEnv("RND")
 	assert.Equal(t, true, ok)

--- a/pkg/test_framework/test_test.go
+++ b/pkg/test_framework/test_test.go
@@ -20,7 +20,7 @@ func TestStartQuick(t *testing.T) {
 	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
 	// NOTE: buildEnv never overwrites existing env. variable
 	_ = os.Unsetenv("RND")
-	kube := startHarness(options, sinks)
+	kube := startHarness(options, sinks, nil)
 	assert.NotNil(t, kube)
 	test := kube.NewTest(t).Setup()
 	err := test.StartOperator()
@@ -65,7 +65,7 @@ func TestStartSlowNoCleanup(t *testing.T) {
 	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
 	// NOTE: buildEnv never overwrites existing env. variable
 	_ = os.Unsetenv("RND")
-	kube := startHarness(options, sinks)
+	kube := startHarness(options, sinks, nil)
 	assert.NotNil(t, kube)
 	test := kube.NewTest(t).Setup()
 
@@ -116,7 +116,7 @@ func TestStartSlowWithCleanup(t *testing.T) {
 	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
 	// NOTE: buildEnv never overwrites existing env. variable
 	_ = os.Unsetenv("RND")
-	kube := startHarness(options, sinks)
+	kube := startHarness(options, sinks, nil)
 	assert.NotNil(t, kube)
 	test := kube.NewTest(t).Setup()
 


### PR DESCRIPTION
This comes with some breaking changes:
* `Start()` no longer takes a `testing.M` parameter (it was never used)
* `Client()` function is gone, users are expected to refer to `Kube.Client` directly

Also, both schema and sinks are now "proper" (as far as such thing is possible in Go) optional parameters, and users no longer need to pass either of those to `Start()` function. The only expected parameter is options.