### PR TITLE
Change Start() signature again

### DIFF
--- a/pkg/test_framework/harness.go
+++ b/pkg/test_framework/harness.go
@@ -110,30 +110,16 @@ func Parse() *Options {
 }
 
 // We have a fair number of optional parameters here, let's use poor man's default
-func Start(options Options, args ... interface{}) {
+func Start(options Options, sinks* Sinks, scheme* runtime.Scheme) {
 	// NOTE: We call "sanitize" functions both here and in Parse() to avoid
 	// strong coupling, i.e. we do not make strong assumption as to the format
 	// of MakeDir and Prefix here, hence allowing the user to skip Parse()
 	options.MakeDir = sanitizeMakeDir(options.MakeDir)
 	options.Prefix = sanitizePrefix(options.Prefix)
-	sinks := Sinks{}
-	var scheme *runtime.Scheme = nil
-	for _, v := range(args) {
-		switch t := v.(type) {
-		case Sinks:
-			sinks = t
-		case *Sinks:
-			sinks = *t
-		case runtime.Scheme:
-			scheme = &t
-		case *runtime.Scheme:
-			scheme = t
-		default:
-			log.Panicf("Unsupported type %t", v)
-		}
+	if sinks == nil {
+		sinks = &Sinks{}
 	}
-
-	Kube = startHarness(options, sinks, scheme)
+	Kube = startHarness(options, *sinks, scheme)
 	Kube.Client = newClient(scheme)
 }
 

--- a/pkg/test_framework/waitfor_test.go
+++ b/pkg/test_framework/waitfor_test.go
@@ -17,7 +17,7 @@ func TestWaitFor_Basic(t *testing.T) {
 		return
 	}
 	options := *newOptions("itest")
-	Start(options)
+	Start(options, nil, nil)
 	defer Kube.Close()
 
 	// See if the kubernetes service is available


### PR DESCRIPTION
Taking a variadic parameter of interface{} is not a very Go-langish thing to do, let's add some more structure to this function call