### PR TITLE
Command line options improvements

### DIFF
--- a/pkg/test_framework/harness.go
+++ b/pkg/test_framework/harness.go
@@ -61,11 +61,11 @@ func (h *Harness) OpenManifest(manifest string) (*os.File, error) {
 
 type Options struct {
 	harness.Options
-	Makefile           string
-	MakeDir            string
-	Prefix             string
-	OperatorStartDelay time.Duration
-	EnvAlways          bool
+	Makefile      string
+	MakeDir       string
+	Prefix        string
+	OperatorDelay time.Duration
+	EnvAlways     bool
 }
 
 // Users can use these to capture the "console" output from the spawned sub-processes rather than
@@ -79,13 +79,13 @@ type Sinks struct {
 var Kube *Harness
 
 type ParseOptions struct {
-	MakeDir            string
-	Manifests          string
-	Prefix             string
-	NoCleanup          bool
-	OperatorStartDelay time.Duration
-	EnvAlways          bool
-	OsArgs             []string
+	MakeDir       string
+	Manifests     string
+	Prefix        string
+	NoCleanup     bool
+	OperatorDelay time.Duration
+	EnvAlways     bool
+	OsArgs        []string
 }
 
 type ParseOptionFn func (a* ParseOptions)
@@ -116,7 +116,7 @@ func DefaultNoCleanup() ParseOptionFn {
 
 func DefaultOperatorDelay(opdelay time.Duration) ParseOptionFn {
 	return func(a* ParseOptions) {
-		a.OperatorStartDelay = opdelay
+		a.OperatorDelay = opdelay
 	}
 }
 
@@ -135,13 +135,13 @@ func OverrideOsArgs(osargs []string) ParseOptionFn {
 // We are making use of Functional Options pattern here.
 func Parse(opts ...ParseOptionFn) *Options {
 	args := ParseOptions{
-		MakeDir:            "",
-		Manifests:          "manifests",
-		Prefix:             "test",
-		NoCleanup:          false,
-		OperatorStartDelay: 2 * time.Second,
-		EnvAlways:          false,
-		OsArgs:             os.Args[1:],
+		MakeDir:       "",
+		Manifests:     "manifests",
+		Prefix:        "test",
+		NoCleanup:     false,
+		OperatorDelay: 2 * time.Second,
+		EnvAlways:     false,
+		OsArgs:        os.Args[1:],
 	}
 	for _, opt := range opts {
 		opt(&args)
@@ -154,7 +154,7 @@ func Parse(opts ...ParseOptionFn) *Options {
 	makedir := cmdline.String("k8s.makedir", args.MakeDir, "directory to makefile")
 	prefix := cmdline.String("k8s.prefix", args.Prefix, "prefix for make cluster manipulation targets")
 	manifests := cmdline.String("k8s.manifests", args.Manifests, "directory to K8s manifests")
-	delay := cmdline.Duration("k8s.op-delay", args.OperatorStartDelay, "operator start delay")
+	delay := cmdline.Duration("k8s.op-delay", args.OperatorDelay, "operator start delay")
 	envAlways := cmdline.Bool("k8s.env-always", args.EnvAlways, "always use environment variables from makefile")
 	_ = cmdline.Parse(args.OsArgs)
 
@@ -167,11 +167,11 @@ func Parse(opts ...ParseOptionFn) *Options {
 			NoCleanup:         *noCleanup,
 			Logger:            &logger.PrintfLogger{},
 		},
-		Makefile:           *makefile,
-		MakeDir:            sanitizeMakeDir(*makedir),
-		Prefix:             sanitizePrefix(*prefix),
-		OperatorStartDelay: *delay,
-		EnvAlways:          *envAlways,
+		Makefile:      *makefile,
+		MakeDir:       sanitizeMakeDir(*makedir),
+		Prefix:        sanitizePrefix(*prefix),
+		OperatorDelay: *delay,
+		EnvAlways:     *envAlways,
 	}
 	if *verbose {
 		options.LogLevel = logger.Debug

--- a/pkg/test_framework/harness_test.go
+++ b/pkg/test_framework/harness_test.go
@@ -230,16 +230,17 @@ $`, cout.String())
 }
 
 func TestStart(t *testing.T) {
-	options := *newOptions()
+	options := *newOptions(DefaultEnvAlways())
 	cout := bytes.Buffer{}
 	cerr := bytes.Buffer{}
 	operator := bytes.Buffer{}
 	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
 	// NOTE: buildEnv never overwrites existing env. variable
-	_ = os.Unsetenv("RND")
+	_ = os.Setenv("RND", "DUMMYDATA")
 	kube := startHarness(options, sinks, nil)
 	assert.NotNil(t, kube)
 	rnd, ok := os.LookupEnv("RND")
+	assert.NotEqual(t, "DUMMYDATA", rnd)
 	assert.Equal(t, true, ok)
 	cmp := `^echo "export RND=.*
 echo "tests-cluster-start \$\{RND\}"

--- a/pkg/test_framework/test.go
+++ b/pkg/test_framework/test.go
@@ -146,7 +146,7 @@ func startOperator(options Options, sinks Sinks) error {
 	args := []string{"make", "-s", "-f", makefile, "-C", makedir, options.operatorStart()}
 	log.Printf("Starting %v ...", args)
 	// let's use sinks.Operator as Stdout for operator output
-	handler := asynchronousHandler{options.OperatorStartDelay, nil}
+	handler := asynchronousHandler{options.OperatorDelay, nil}
 	if err := start(&handler, sinks.Operator,  nil, args); err != nil {
 		return err
 	}

--- a/pkg/test_framework/test_test.go
+++ b/pkg/test_framework/test_test.go
@@ -55,7 +55,7 @@ $`, rnd, rnd, rnd, rnd, ns, rnd)
 }
 
 func TestStartSlowNoCleanup(t *testing.T) {
-	options := *newOptions("test-sleep05", "nocleanup")
+	options := *newOptions(DefaultPrefix("test-sleep05"), DefaultNoCleanup())
 	options.OperatorDelay = 200 * time.Millisecond
 	cout := bytes.Buffer{}
 	cerr := bytes.Buffer{}
@@ -105,7 +105,7 @@ $`, rnd, rnd, rnd, ns)
 }
 
 func TestStartSlowWithCleanup(t *testing.T) {
-	options := *newOptions("test-sleep05")
+	options := *newOptions(DefaultPrefix("test-sleep05"))
 	options.OperatorDelay = 200 * time.Millisecond
 	cout := bytes.Buffer{}
 	cerr := bytes.Buffer{}

--- a/pkg/test_framework/test_test.go
+++ b/pkg/test_framework/test_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestStartQuick(t *testing.T) {
 	options := *newOptions()
-	options.OperatorStartDelay = 500 * time.Millisecond
+	options.OperatorDelay = 500 * time.Millisecond
 	cout := bytes.Buffer{}
 	cerr := bytes.Buffer{}
 	operator := bytes.Buffer{}
@@ -56,7 +56,7 @@ $`, rnd, rnd, rnd, rnd, ns, rnd)
 
 func TestStartSlowNoCleanup(t *testing.T) {
 	options := *newOptions("test-sleep05", "nocleanup")
-	options.OperatorStartDelay = 200 * time.Millisecond
+	options.OperatorDelay = 200 * time.Millisecond
 	cout := bytes.Buffer{}
 	cerr := bytes.Buffer{}
 	operator := bytes.Buffer{}
@@ -106,7 +106,7 @@ $`, rnd, rnd, rnd, ns)
 
 func TestStartSlowWithCleanup(t *testing.T) {
 	options := *newOptions("test-sleep05")
-	options.OperatorStartDelay = 200 * time.Millisecond
+	options.OperatorDelay = 200 * time.Millisecond
 	cout := bytes.Buffer{}
 	cerr := bytes.Buffer{}
 	operator := bytes.Buffer{}

--- a/pkg/test_framework/waitfor_test.go
+++ b/pkg/test_framework/waitfor_test.go
@@ -16,7 +16,7 @@ func TestWaitFor_Basic(t *testing.T) {
 		t.Skip("This test is meant to run on Linux only")
 		return
 	}
-	options := *newOptions("itest")
+	options := *newOptions(DefaultPrefix("itest"))
 	Start(options, nil, nil)
 	defer Kube.Close()
 


### PR DESCRIPTION
This PR will:
* add new option `-k8s.env-always` which can be used to fix flaky tests caused by pre-existing environment variables
* add the ability to set defaults of all options from user tests (except verbosity) when parsing command line and
* add unit tests for options parsing

There is also a minor breaking change due to rename of `OperatorStartDelay` to `OperatorDelay`, most users won't notice.
