### PR TITLE
Add support for running arbitrary target from test framework

### DIFF
--- a/pkg/test_framework/test.go
+++ b/pkg/test_framework/test.go
@@ -47,6 +47,10 @@ func (t *Test) StopOperator() {
 	}
 }
 
+func (t *Test) RunTarget(name string) error {
+	return runTarget(t.harness.Options, t.harness.Sinks, name)
+}
+
 func (t *Test) DeleteDeployment(d *appsv1.Deployment, timeout time.Duration) {
 	t.Test.DeleteDeployment(d)
 	t.Test.WaitForDeploymentDeleted(d, timeout)
@@ -175,4 +179,20 @@ func cleanup(options Options, sinks Sinks) {
 	// allow for errors here
 	_ = run(sinks.Stdout, sinks.Stderr, args)
 	log.Print("... done")
+}
+
+func runTarget(options Options, sinks Sinks, name string) error {
+	makefile := options.Makefile
+	makedir := options.MakeDir
+	target := options.Prefix + name
+	args := []string{"make", "-s", "-f", makefile, "-C", makedir, target}
+	log.Printf("Running %v ...", args)
+	// allow for errors here
+	err := run(sinks.Stdout, sinks.Stderr, args)
+	if err == nil {
+		log.Print("... done")
+	} else {
+		log.Printf("error running target %s: %v", target, err)
+	}
+	return err
 }

--- a/pkg/test_framework/test_test.go
+++ b/pkg/test_framework/test_test.go
@@ -151,3 +151,21 @@ $`, rnd, rnd, rnd, rnd, ns, rnd, ns, rnd)
 	assert.Equal(t, cmp, operator.String())
 	assert.Empty(t, cerr.String())
 }
+
+func TestRunArbitraryTarget(t *testing.T) {
+	options := *newOptions(DefaultEnvAlways())
+	cout := bytes.Buffer{}
+	cerr := bytes.Buffer{}
+	operator := bytes.Buffer{}
+	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
+	kube := startHarness(options, sinks, nil)
+	assert.NotNil(t, kube)
+
+	test := kube.NewTest(t).Setup()
+	err := test.RunTarget("foo")
+	assert.NoError(t, err)
+
+	// try again, detecting an error this time
+	err = test.RunTarget("bar")
+	assert.NotNil(t, err)
+}

--- a/pkg/test_framework/test_test.go
+++ b/pkg/test_framework/test_test.go
@@ -1,10 +1,9 @@
 package framework
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -12,13 +11,8 @@ import (
 )
 
 func TestStartQuick(t *testing.T) {
-	options := *newOptions()
-	options.OperatorDelay = 500 * time.Millisecond
-	cout := bytes.Buffer{}
-	cerr := bytes.Buffer{}
-	operator := bytes.Buffer{}
-	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
-	// NOTE: buildEnv never overwrites existing env. variable
+	options := *newOptions(DefaultOperatorDelay(500 * time.Millisecond))
+	sinks, cout, cerr, operator := newSinks()
 	_ = os.Unsetenv("RND")
 	kube := startHarness(options, sinks, nil)
 	assert.NotNil(t, kube)
@@ -55,14 +49,13 @@ $`, rnd, rnd, rnd, rnd, ns, rnd)
 }
 
 func TestStartSlowNoCleanup(t *testing.T) {
-	options := *newOptions(DefaultPrefix("test-sleep05"), DefaultNoCleanup())
-	options.OperatorDelay = 200 * time.Millisecond
-	cout := bytes.Buffer{}
-	cerr := bytes.Buffer{}
-	operator := bytes.Buffer{}
-	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
-	// NOTE: buildEnv never overwrites existing env. variable
-	_ = os.Unsetenv("RND")
+	options := *newOptions(
+		DefaultEnvAlways(),
+		DefaultPrefix("test-sleep05"),
+		DefaultNoCleanup(),
+		DefaultOperatorDelay(200 * time.Millisecond),
+	)
+	sinks, cout, cerr, operator := newSinks()
 	kube := startHarness(options, sinks, nil)
 	assert.NotNil(t, kube)
 	test := kube.NewTest(t).Setup()
@@ -105,14 +98,12 @@ $`, rnd, rnd, rnd, ns)
 }
 
 func TestStartSlowWithCleanup(t *testing.T) {
-	options := *newOptions(DefaultPrefix("test-sleep05"))
-	options.OperatorDelay = 200 * time.Millisecond
-	cout := bytes.Buffer{}
-	cerr := bytes.Buffer{}
-	operator := bytes.Buffer{}
-	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
-	// NOTE: buildEnv never overwrites existing env. variable
-	_ = os.Unsetenv("RND")
+	options := *newOptions(
+		DefaultEnvAlways(),
+		DefaultPrefix("test-sleep05"),
+		DefaultOperatorDelay(200 * time.Millisecond),
+	)
+	sinks, cout, cerr, operator := newSinks()
 	kube := startHarness(options, sinks, nil)
 	assert.NotNil(t, kube)
 	test := kube.NewTest(t).Setup()
@@ -153,19 +144,54 @@ $`, rnd, rnd, rnd, rnd, ns, rnd, ns, rnd)
 }
 
 func TestRunArbitraryTarget(t *testing.T) {
-	options := *newOptions(DefaultEnvAlways())
-	cout := bytes.Buffer{}
-	cerr := bytes.Buffer{}
-	operator := bytes.Buffer{}
-	sinks := Sinks{[]io.Writer{&cout}, []io.Writer{&cerr}, []io.Writer{&operator}}
+	options := *newOptions(
+		DefaultEnvAlways(),
+		DefaultPrefix("test-sleep05"),
+		DefaultOperatorDelay(200 * time.Millisecond),
+	)
+	sinks, cout, _, _ := newSinks()
 	kube := startHarness(options, sinks, nil)
 	assert.NotNil(t, kube)
 
 	test := kube.NewTest(t).Setup()
-	err := test.RunTarget("foo")
+	// this will block long enough to register "operator running"
+	err := test.StartOperator()
+	assert.NoError(t, err)
+
+	err = test.RunTarget("foo")
 	assert.NoError(t, err)
 
 	// try again, detecting an error this time
 	err = test.RunTarget("bar")
 	assert.NotNil(t, err)
+
+	rnd, ok := os.LookupEnv("RND")
+	assert.Equal(t, true, ok)
+	ns := test.Namespace
+	cmp := `^echo "export RND=.*
+echo "test-sleep05-cluster-start \$\{RND\}"
+echo "test-sleep05-cluster-stop \$\{RND\}"
+echo "test-sleep05-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+sleep 0\.5s
+echo "test-sleep05-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "test-sleep05-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+`
+	cmp += fmt.Sprintf(`export RND=%s
+test-sleep05-cluster-stop %s
+test-sleep05-cluster-start %s
+test-sleep05-foo %s %s
+test-sleep05-bar %s %s.*error
+`, rnd, rnd, rnd, rnd, ns, rnd, ns)
+	if runtime.GOOS == "linux" {
+		// I am very sorry, but there does not seem to be a way to tell the GNU make to keep quiet here
+		cmp += "Makefile:.* failed\n"
+	}
+	cmp += fmt.Sprintf(`test-sleep05-operator-stop %s %s
+test-sleep05-cleanup %s %s
+test-sleep05-cluster-stop %s
+$`, rnd, ns, rnd, ns, rnd)
+	test.Close()
+	err = kube.Close()
+	assert.NoError(t, err)
+	assert.Regexp(t, cmp, cout.String())
 }

--- a/pkg/test_framework/tests/Makefile
+++ b/pkg/test_framework/tests/Makefile
@@ -23,6 +23,13 @@ itest-cluster-stop:
 	  rm $${CIDFILE}; \
 	fi
 
+tests-foo:
+	@echo "test-foo $${RND} $${TEST_OPERATOR_NS}"
+
+tests-bar:
+	@echo "test-bar $${RND} $${TEST_OPERATOR_NS}, expected to raise an error"
+	false
+
 fail:
 	$(error $*)
 

--- a/pkg/test_framework/tests/Makefile
+++ b/pkg/test_framework/tests/Makefile
@@ -23,11 +23,11 @@ itest-cluster-stop:
 	  rm $${CIDFILE}; \
 	fi
 
-tests-foo:
-	@echo "test-foo $${RND} $${TEST_OPERATOR_NS}"
+test-sleep05-foo:
+	@echo "test-sleep05-foo $${RND} $${TEST_OPERATOR_NS}"
 
-tests-bar:
-	@echo "test-bar $${RND} $${TEST_OPERATOR_NS}, expected to raise an error"
+test-sleep05-bar:
+	@echo "test-sleep05-bar $${RND} $${TEST_OPERATOR_NS}, expected to raise an error"
 	false
 
 fail:


### PR DESCRIPTION
This is expected to give the users ability to execute things which would be difficult to perform otherwise, e.g. simulate weird cluster errors etc. In order to keep the test targets separated, prefix will be applied like for all other targets