### PR TITLE
Add TEST_COUNT to support parallel tests

### DIFF
--- a/pkg/test_framework/harness.go
+++ b/pkg/test_framework/harness.go
@@ -52,6 +52,7 @@ func (h *Harness) NewTest(t htesting.T) *Test {
 		operatorRunning: false,
 		harness:         h,
 		testCount:       atomic.AddUint32(&h.internalState.testCounter, 1),
+		envs:            map[string]string{},
 	}
 }
 
@@ -287,7 +288,7 @@ func checkMakefile(options Options, sinks Sinks) {
 	check := func(target string) {
 		args := []string{"make", "-s", "-f", makefile, "-C", makedir, "--dry-run", target}
 		log.Printf("Checking %v ...", args)
-		err := run(sinks.Stdout, sinks.Stderr, args)
+		err := run(sinks.Stdout, sinks.Stderr, args, nil)
 		if err != nil {
 			log.Panicf("error checking target %s: %v", target, err)
 		} else {
@@ -323,7 +324,7 @@ func buildEnv(options Options, sinks Sinks) {
 	// clone sinks.Stdout and add exports
 	cout := append([]io.Writer{}, sinks.Stdout...)
 	cout = append(cout, &exports)
-	err := run(cout, sinks.Stderr, args)
+	err := run(cout, sinks.Stderr, args, nil)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -349,7 +350,7 @@ func startCluster(options Options, sinks Sinks) {
 	makedir := options.MakeDir
 	args := []string{"make", "-s", "-f", makefile, "-C", makedir, options.clusterStart()}
 	log.Printf("Running %v ...", args)
-	err := run(sinks.Stdout, sinks.Stderr, args)
+	err := run(sinks.Stdout, sinks.Stderr, args, nil)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -371,6 +372,6 @@ func stopCluster(options Options, sinks Sinks) {
 	args := []string{"make", "-s", "-f", makefile, "-C", makedir, options.clusterStop()}
 	log.Printf("Running %v ...", args)
 	// if this fails that's perfectly OK - the cluster might not have been running!
-	_ = run(sinks.Stdout, sinks.Stderr, args)
+	_ = run(sinks.Stdout, sinks.Stderr, args, nil)
 	log.Print("... done")
 }

--- a/pkg/test_framework/harness_test.go
+++ b/pkg/test_framework/harness_test.go
@@ -78,9 +78,9 @@ func TestSanitizePrefix(t *testing.T) {
 func TestRunNoOutput(t *testing.T) {
 	args := []string{"make", "-s", "-C", "tests", "default"}
 	_ = os.Setenv("RND", "BAZ")
-	err := run([]io.Writer{}, nil, args)
+	err := run([]io.Writer{}, nil, args, nil)
 	assert.NoError(t, err)
-	err = run(nil, []io.Writer{}, args)
+	err = run(nil, []io.Writer{}, args, nil)
 	assert.NoError(t, err)
 }
 
@@ -89,8 +89,8 @@ func TestRunSimple(t *testing.T) {
 	cout := bytes.Buffer{}
 	cerr := bytes.Buffer{}
 	args := []string{"make", "-s", "-C", "tests", "default"}
-	_ = os.Setenv("RND", "BAZ")
-	err := run([]io.Writer{&cout}, []io.Writer{&cerr}, args)
+	envs := map[string]string{"RND": "BAZ"}
+	err := run([]io.Writer{&cout}, []io.Writer{&cerr}, args, envs)
 	assert.NoError(t, err)
 	assert.Equal(t, "default BAZ\n", cout.String())
 	assert.Empty(t, cerr.String())

--- a/pkg/test_framework/harness_test.go
+++ b/pkg/test_framework/harness_test.go
@@ -217,9 +217,9 @@ func TestCheckAll(t *testing.T) {
 	assert.Regexp(t, `^echo "export RND=.*
 echo "tests-cluster-start \$\{RND\}"
 echo "tests-cluster-stop \$\{RND\}"
-echo "tests-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "tests-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "tests-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "tests-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "tests-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "tests-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 $`, cout.String())
 	assert.Empty(t, cerr.String())
 	assert.Empty(t, operator.String())
@@ -249,9 +249,9 @@ func TestCheckNoCleanup(t *testing.T) {
 	checkMakefile(options, sinks)
 	assert.Regexp(t, `^echo "export RND=.*
 echo "fail-close-cluster-start \$\{RND\}"
-echo "fail-close-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "fail-close-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "fail-close-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "fail-close-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "fail-close-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "fail-close-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 $`, cout.String())
 	assert.Empty(t, cerr.String())
 	assert.Empty(t, operator.String())
@@ -270,9 +270,9 @@ func TestStart(t *testing.T) {
 	cmp := `^echo "export RND=.*
 echo "tests-cluster-start \$\{RND\}"
 echo "tests-cluster-stop \$\{RND\}"
-echo "tests-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "tests-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "tests-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "tests-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "tests-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "tests-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 `
 	err := kube.Close()
 	assert.NoError(t, err)
@@ -300,9 +300,9 @@ func TestStartNoCleanup(t *testing.T) {
 	assert.Equal(t, true, ok)
 	cmp := `^echo "export RND=.*
 echo "fail-close-cluster-start \$\{RND\}"
-echo "fail-close-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "fail-close-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "fail-close-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "fail-close-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "fail-close-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "fail-close-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 `
 	err := kube.Close()
 	assert.NoError(t, err)

--- a/pkg/test_framework/test.go
+++ b/pkg/test_framework/test.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"fmt"
 	"log"
-	"os"
 	"os/exec"
 	"sync"
 	"sync/atomic"
@@ -19,6 +18,7 @@ type Test struct {
 	operatorRunning bool
 	harness         *Harness
 	testCount       uint32
+	envs            map[string]string
 }
 
 func (t *Test) Setup() *Test {
@@ -26,8 +26,8 @@ func (t *Test) Setup() *Test {
 	if t.harness.Harness.KubeClient() != nil {
 		_ = t.Test.Setup()
 	}
-	_ = os.Setenv("TEST_OPERATOR_NS", t.Namespace)
-	_ = os.Setenv("TEST_COUNT", fmt.Sprintf("%d", t.testCount))
+	t.envs["TEST_OPERATOR_NS"] = t.Namespace
+	t.envs["TEST_COUNT"] = fmt.Sprintf("%d", t.testCount)
 	return t
 }
 
@@ -35,7 +35,7 @@ func (t *Test) StartOperator() error {
 	if t.operatorRunning == true {
 		return fmt.Errorf("operator already started")
 	}
-	err := startOperator(t.harness.Options, t.harness.Sinks)
+	err := startOperator(t.harness.Options, t.harness.Sinks, t.envs)
 	if err == nil {
 		t.operatorRunning = true
 	}
@@ -44,13 +44,13 @@ func (t *Test) StartOperator() error {
 
 func (t *Test) StopOperator() {
 	if t.operatorRunning {
-		stopOperator(t.harness.Options, t.harness.Sinks)
+		stopOperator(t.harness.Options, t.harness.Sinks, t.envs)
 		t.operatorRunning = false
 	}
 }
 
 func (t *Test) RunTarget(name string) error {
-	return runTarget(t.harness.Options, t.harness.Sinks, name)
+	return runTarget(t.harness.Options, t.harness.Sinks, name, t.envs)
 }
 
 func (t *Test) DeleteDeployment(d *appsv1.Deployment, timeout time.Duration) {
@@ -61,15 +61,13 @@ func (t *Test) DeleteDeployment(d *appsv1.Deployment, timeout time.Duration) {
 func (t *Test) Close() {
 	// If panicking, let Test.Close() do its thing only and keep the operator running
 	defer func () {
-		_ = os.Unsetenv("TEST_OPERATOR_NS")
-		_ = os.Unsetenv("TEST_COUNT")
 		t.Test.Close()
 	}()
 	if r := recover(); r != nil {
 		panic(r)
 	} else {
 		t.StopOperator()
-		cleanup(t.harness.Options, t.harness.Sinks)
+		cleanup(t.harness.Options, t.harness.Sinks, t.envs)
 	}
 }
 
@@ -147,30 +145,30 @@ func(h* asynchronousHandler) Handle(cmd *exec.Cmd, wg *sync.WaitGroup) {
 	}
 }
 
-func startOperator(options Options, sinks Sinks) error {
+func startOperator(options Options, sinks Sinks, envs map[string]string) error {
 	makefile := options.Makefile
 	makedir := options.MakeDir
 	args := []string{"make", "-s", "-f", makefile, "-C", makedir, options.operatorStart()}
 	log.Printf("Starting %v ...", args)
 	// let's use sinks.Operator as Stdout for operator output
 	handler := asynchronousHandler{options.OperatorDelay, nil}
-	if err := start(&handler, sinks.Operator,  nil, args); err != nil {
+	if err := start(&handler, sinks.Operator,  nil, args, envs); err != nil {
 		return err
 	}
 	return handler.result
 }
 
-func stopOperator(options Options, sinks Sinks) {
+func stopOperator(options Options, sinks Sinks, envs map[string]string) {
 	makefile := options.Makefile
 	makedir := options.MakeDir
 	args := []string{"make", "-s", "-f", makefile, "-C", makedir, options.operatorStop()}
 	log.Printf("Running %v ...", args)
 	// allow for errors here
-	_ = run(sinks.Stdout, sinks.Stderr, args)
+	_ = run(sinks.Stdout, sinks.Stderr, args, envs)
 	log.Print("... done")
 }
 
-func cleanup(options Options, sinks Sinks) {
+func cleanup(options Options, sinks Sinks, envs map[string]string) {
 	if options.NoCleanup {
 		log.Printf("Keeping the test objects")
 		return
@@ -180,18 +178,18 @@ func cleanup(options Options, sinks Sinks) {
 	args := []string{"make", "-s", "-f", makefile, "-C", makedir, options.cleanup()}
 	log.Printf("Running %v ...", args)
 	// allow for errors here
-	_ = run(sinks.Stdout, sinks.Stderr, args)
+	_ = run(sinks.Stdout, sinks.Stderr, args, envs)
 	log.Print("... done")
 }
 
-func runTarget(options Options, sinks Sinks, name string) error {
+func runTarget(options Options, sinks Sinks, name string, envs map[string]string) error {
 	makefile := options.Makefile
 	makedir := options.MakeDir
 	target := options.Prefix + name
 	args := []string{"make", "-s", "-f", makefile, "-C", makedir, target}
 	log.Printf("Running %v ...", args)
 	// allow for errors here
-	err := run(sinks.Stdout, sinks.Stderr, args)
+	err := run(sinks.Stdout, sinks.Stderr, args, envs)
 	if err == nil {
 		log.Print("... done")
 	} else {

--- a/pkg/test_framework/test.go
+++ b/pkg/test_framework/test.go
@@ -18,6 +18,7 @@ type Test struct {
 
 	operatorRunning bool
 	harness         *Harness
+	testCount       uint32
 }
 
 func (t *Test) Setup() *Test {
@@ -26,6 +27,7 @@ func (t *Test) Setup() *Test {
 		_ = t.Test.Setup()
 	}
 	_ = os.Setenv("TEST_OPERATOR_NS", t.Namespace)
+	_ = os.Setenv("TEST_COUNT", fmt.Sprintf("%d", t.testCount))
 	return t
 }
 
@@ -60,6 +62,7 @@ func (t *Test) Close() {
 	// If panicking, let Test.Close() do its thing only and keep the operator running
 	defer func () {
 		_ = os.Unsetenv("TEST_OPERATOR_NS")
+		_ = os.Unsetenv("TEST_COUNT")
 		t.Test.Close()
 	}()
 	if r := recover(); r != nil {

--- a/pkg/test_framework/test_test.go
+++ b/pkg/test_framework/test_test.go
@@ -20,12 +20,8 @@ func TestStartQuick(t *testing.T) {
 	err := test.StartOperator()
 	// error because make tests-operator-start is not blocking
 	assert.NotNil(t, err)
-	ns, nset := os.LookupEnv("TEST_OPERATOR_NS")
-	assert.Equal(t,true, nset)
-	assert.Equal(t, test.Namespace, ns)
-	_, nset = os.LookupEnv("TEST_COUNT")
-	assert.Equal(t,true, nset)
 
+	ns := test.Namespace
 	rnd, ok := os.LookupEnv("RND")
 	assert.Equal(t, true, ok)
 	cmp := `^echo "export RND=.*
@@ -65,23 +61,12 @@ func TestStartSlowNoCleanup(t *testing.T) {
 	// this will block long enough to register "operator running"
 	err := test.StartOperator()
 	assert.NoError(t, err)
-	ns, nset := os.LookupEnv("TEST_OPERATOR_NS")
-	assert.Equal(t, true, nset)
-	assert.Equal(t, test.Namespace, ns)
-	count1, nset := os.LookupEnv("TEST_COUNT")
-	assert.Equal(t,true, nset)
-	assert.Equal(t, "1", count1)
 
 	err = test.StartOperator()
 	// operator already started
 	assert.NotNil(t, err)
-	ns, nset = os.LookupEnv("TEST_OPERATOR_NS")
-	assert.Equal(t, true, nset)
-	assert.Equal(t, test.Namespace, ns)
-	count2, nset := os.LookupEnv("TEST_COUNT")
-	assert.Equal(t,true, nset)
-	assert.Equal(t, "1", count2)
 
+	ns := test.Namespace
 	rnd, ok := os.LookupEnv("RND")
 	assert.Equal(t, true, ok)
 	cmp := `^echo "export RND=.*
@@ -120,12 +105,8 @@ func TestStartSlowWithCleanup(t *testing.T) {
 	// this will block long enough to register "operator running"
 	err := test.StartOperator()
 	assert.NoError(t, err)
-	ns, nset := os.LookupEnv("TEST_OPERATOR_NS")
-	assert.Equal(t, true, nset)
-	assert.Equal(t, test.Namespace, ns)
-	_, nset = os.LookupEnv("TEST_COUNT")
-	assert.Equal(t,true, nset)
 
+	ns := test.Namespace
 	rnd, ok := os.LookupEnv("RND")
 	assert.Equal(t, true, ok)
 	cmp := `^echo "export RND=.*
@@ -147,10 +128,6 @@ $`, rnd, rnd, rnd, rnd, ns, rnd, ns, rnd)
 	test.Close()
 	err = kube.Close()
 	assert.NoError(t, err)
-	_, nset = os.LookupEnv("TEST_OPERATOR_NS")
-	assert.Equal(t, false, nset)
-	_, nset = os.LookupEnv("TEST_COUNT")
-	assert.Equal(t, false, nset)
 
 	assert.Regexp(t, cmp, cout.String())
 	// stdout output of the operator goes to the operator sink

--- a/pkg/test_framework/test_test.go
+++ b/pkg/test_framework/test_test.go
@@ -23,27 +23,29 @@ func TestStartQuick(t *testing.T) {
 	ns, nset := os.LookupEnv("TEST_OPERATOR_NS")
 	assert.Equal(t,true, nset)
 	assert.Equal(t, test.Namespace, ns)
+	_, nset = os.LookupEnv("TEST_COUNT")
+	assert.Equal(t,true, nset)
 
 	rnd, ok := os.LookupEnv("RND")
 	assert.Equal(t, true, ok)
 	cmp := `^echo "export RND=.*
 echo "tests-cluster-start \$\{RND\}"
 echo "tests-cluster-stop \$\{RND\}"
-echo "tests-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "tests-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "tests-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "tests-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "tests-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "tests-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 `
 	cmp += fmt.Sprintf(`export RND=%s
 tests-cluster-stop %s
 tests-cluster-start %s
-tests-cleanup %s %s
+tests-cleanup %s %s 1
 tests-cluster-stop %s
 $`, rnd, rnd, rnd, rnd, ns, rnd)
 	test.Close()
 	err = kube.Close()
 	assert.NoError(t, err)
 	assert.Regexp(t, cmp, cout.String())
-	cmp = fmt.Sprintf("tests-operator-start %s %s\n", rnd, test.Namespace)
+	cmp = fmt.Sprintf("tests-operator-start %s %s 1\n", rnd, test.Namespace)
 	assert.Equal(t, cmp, operator.String())
 	assert.Empty(t, cerr.String())
 }
@@ -66,25 +68,32 @@ func TestStartSlowNoCleanup(t *testing.T) {
 	ns, nset := os.LookupEnv("TEST_OPERATOR_NS")
 	assert.Equal(t, true, nset)
 	assert.Equal(t, test.Namespace, ns)
+	count1, nset := os.LookupEnv("TEST_COUNT")
+	assert.Equal(t,true, nset)
+	assert.Equal(t, "1", count1)
+
 	err = test.StartOperator()
 	// operator already started
 	assert.NotNil(t, err)
 	ns, nset = os.LookupEnv("TEST_OPERATOR_NS")
 	assert.Equal(t, true, nset)
 	assert.Equal(t, test.Namespace, ns)
+	count2, nset := os.LookupEnv("TEST_COUNT")
+	assert.Equal(t,true, nset)
+	assert.Equal(t, "1", count2)
 
 	rnd, ok := os.LookupEnv("RND")
 	assert.Equal(t, true, ok)
 	cmp := `^echo "export RND=.*
 echo "test-sleep05-cluster-start \$\{RND\}"
-echo "test-sleep05-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "test-sleep05-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 sleep 0\.5s
-echo "test-sleep05-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "test-sleep05-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "test-sleep05-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "test-sleep05-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 `
 	cmp += fmt.Sprintf(`export RND=%s
 test-sleep05-cluster-start %s
-test-sleep05-operator-stop %s %s
+test-sleep05-operator-stop %s %s 1
 $`, rnd, rnd, rnd, ns)
 	// intentionally not calling StopOperator(), test.Close() should call it for us
 	test.Close()
@@ -92,7 +101,7 @@ $`, rnd, rnd, rnd, ns)
 	assert.NoError(t, err)
 	assert.Regexp(t, cmp, cout.String())
 	// stdout output of the operator goes to the operator sink
-	cmp = fmt.Sprintf("test-sleep05-operator-start %s %s\n", rnd, ns)
+	cmp = fmt.Sprintf("test-sleep05-operator-start %s %s 1\n", rnd, ns)
 	assert.Equal(t, cmp, operator.String())
 	assert.Empty(t, cerr.String())
 }
@@ -114,31 +123,38 @@ func TestStartSlowWithCleanup(t *testing.T) {
 	ns, nset := os.LookupEnv("TEST_OPERATOR_NS")
 	assert.Equal(t, true, nset)
 	assert.Equal(t, test.Namespace, ns)
+	_, nset = os.LookupEnv("TEST_COUNT")
+	assert.Equal(t,true, nset)
 
 	rnd, ok := os.LookupEnv("RND")
 	assert.Equal(t, true, ok)
 	cmp := `^echo "export RND=.*
 echo "test-sleep05-cluster-start \$\{RND\}"
 echo "test-sleep05-cluster-stop \$\{RND\}"
-echo "test-sleep05-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "test-sleep05-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 sleep 0\.5s
-echo "test-sleep05-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "test-sleep05-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "test-sleep05-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "test-sleep05-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 `
 	cmp += fmt.Sprintf(`export RND=%s
 test-sleep05-cluster-stop %s
 test-sleep05-cluster-start %s
-test-sleep05-operator-stop %s %s
-test-sleep05-cleanup %s %s
+test-sleep05-operator-stop %s %s 1
+test-sleep05-cleanup %s %s 1
 test-sleep05-cluster-stop %s
 $`, rnd, rnd, rnd, rnd, ns, rnd, ns, rnd)
 	// intentionally not calling StopOperator(), test.Close() should call it for us
 	test.Close()
 	err = kube.Close()
 	assert.NoError(t, err)
+	_, nset = os.LookupEnv("TEST_OPERATOR_NS")
+	assert.Equal(t, false, nset)
+	_, nset = os.LookupEnv("TEST_COUNT")
+	assert.Equal(t, false, nset)
+
 	assert.Regexp(t, cmp, cout.String())
 	// stdout output of the operator goes to the operator sink
-	cmp = fmt.Sprintf("test-sleep05-operator-start %s %s\n", rnd, ns)
+	cmp = fmt.Sprintf("test-sleep05-operator-start %s %s 1\n", rnd, ns)
 	assert.Equal(t, cmp, operator.String())
 	assert.Empty(t, cerr.String())
 }
@@ -171,23 +187,23 @@ func TestRunArbitraryTarget(t *testing.T) {
 	cmp := `^echo "export RND=.*
 echo "test-sleep05-cluster-start \$\{RND\}"
 echo "test-sleep05-cluster-stop \$\{RND\}"
-echo "test-sleep05-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "test-sleep05-operator-start \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 sleep 0\.5s
-echo "test-sleep05-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\}"
-echo "test-sleep05-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\}"
+echo "test-sleep05-operator-stop \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
+echo "test-sleep05-cleanup \$\{RND\} \$\{TEST_OPERATOR_NS\} \$\{TEST_COUNT\}"
 `
 	cmp += fmt.Sprintf(`export RND=%s
 test-sleep05-cluster-stop %s
 test-sleep05-cluster-start %s
-test-sleep05-foo %s %s
-test-sleep05-bar %s %s.*error
+test-sleep05-foo %s %s 1
+test-sleep05-bar %s %s 1.*error
 `, rnd, rnd, rnd, rnd, ns, rnd, ns)
 	if runtime.GOOS == "linux" {
 		// I am very sorry, but there does not seem to be a way to tell the GNU make to keep quiet here
 		cmp += "Makefile:.* failed\n"
 	}
-	cmp += fmt.Sprintf(`test-sleep05-operator-stop %s %s
-test-sleep05-cleanup %s %s
+	cmp += fmt.Sprintf(`test-sleep05-operator-stop %s %s 1
+test-sleep05-cleanup %s %s 1
 test-sleep05-cluster-stop %s
 $`, rnd, ns, rnd, ns, rnd)
 	test.Close()

--- a/pkg/test_framework/tests/Makefile
+++ b/pkg/test_framework/tests/Makefile
@@ -24,10 +24,10 @@ itest-cluster-stop:
 	fi
 
 test-sleep05-foo:
-	@echo "test-sleep05-foo $${RND} $${TEST_OPERATOR_NS}"
+	@echo "test-sleep05-foo $${RND} $${TEST_OPERATOR_NS} $${TEST_COUNT}"
 
 test-sleep05-bar:
-	@echo "test-sleep05-bar $${RND} $${TEST_OPERATOR_NS}, expected to raise an error"
+	@echo "test-sleep05-bar $${RND} $${TEST_OPERATOR_NS} $${TEST_COUNT}, expected to raise an error"
 	false
 
 fail:
@@ -37,17 +37,17 @@ fail-close-cluster-stop:
 	$(error $*)
 
 test-sleep05-operator-start:
-	@echo "test-sleep05-operator-start $${RND} $${TEST_OPERATOR_NS}"
+	@echo "test-sleep05-operator-start $${RND} $${TEST_OPERATOR_NS} $${TEST_COUNT}"
 	@sleep 0.5s
 
 %-operator-start:
-	@echo "$*-operator-start $${RND} $${TEST_OPERATOR_NS}"
+	@echo "$*-operator-start $${RND} $${TEST_OPERATOR_NS} $${TEST_COUNT}"
 
 %-operator-stop:
-	@echo "$*-operator-stop $${RND} $${TEST_OPERATOR_NS}"
+	@echo "$*-operator-stop $${RND} $${TEST_OPERATOR_NS} $${TEST_COUNT}"
 
 %-cleanup:
-	@echo "$*-cleanup $${RND} $${TEST_OPERATOR_NS}"
+	@echo "$*-cleanup $${RND} $${TEST_OPERATOR_NS} $${TEST_COUNT}"
 
 %-env:
 	@echo "export RND=$$(xxd -l8 -p /dev/urandom)"


### PR DESCRIPTION
An extra environment variable, when used by `Makefile` glue provided by the user, will enable parallel test execution, for things like binary name or port offsets