### PR TITLE
Install binaries in usr/local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,13 @@ docker_build_%:
 deb_%: clean docker_build_%
 	$(DOCKER_RUN) /bin/bash -c ' \
 		$(MAKE) cmd && \
-		mv bin/paasta{-tools-paasta,_go} && \
+		mv bin/paasta{-tools-paasta,} && \
 		fpm --output-type deb --input-type dir --version $(VERSION) \
 			--deb-dist $* --deb-priority optional \
 			--name paasta-tools-go --package dist \
 			--description "CLI tools for PaaSTA in Go" \
 			--package dist/$* \
-			bin=/usr/ && \
+			bin=/usr/local/ && \
 		chown -R $(UID):$(GID) bin dist \
 	'
 


### PR DESCRIPTION
Install binaries in usr/local to have preference over and no conflicts with python paasta-tools