### PR TITLE
Add PaastaMonitoringSpec

### DIFF
--- a/pkg/monitoringspec/monitoringspec.go
+++ b/pkg/monitoringspec/monitoringspec.go
@@ -1,0 +1,109 @@
+package monitoringspec
+
+import (
+	"encoding/json"
+)
+
+// PaastaMonitoringSpec : Spec for PaaSTA service monitoring configuration
+type PaastaMonitoringSpec struct {
+	Team string              `json:"team,omitempty"`
+	Runbook string           `json:"runbook,omitempty"`
+	Tip string               `json:"tip,omitempty"`
+	Page *bool               `json:"page,omitempty"`
+	Ticket *bool             `json:"ticket,omitempty"`
+	NotificationEmail string `json:"notification_email,omitempty"`
+	SlackChannels []string   `json:"slack_channels,omitempty"`
+	Project string           `json:"project,omitempty"`
+	Priority string          `json:"priority,omitempty"`
+	Tags []string            `json:"tags,omitempty"`
+	Components []string      `json:"components,omitempty"`
+	Description string       `json:"description,omitempty"`
+	AlertAfter string        `json:"alert_after,omitempty"`
+	RealertEvery string      `json:"realert_every,omitempty"`
+	CheckEvery string        `json:"check_every,omitempty"`
+	CheckOomEvents *bool     `json:"check_oom_events,omitempty"`
+}
+
+func (in *PaastaMonitoringSpec) DeepCopyInto(out *PaastaMonitoringSpec) {
+	if in.Team != "" {
+		out.Team = in.Team
+	}
+	if in.Runbook != "" {
+		out.Runbook = in.Runbook
+	}
+	if in.Tip != "" {
+		out.Tip = in.Tip
+	}
+	if in.Page != nil {
+		in, out := &in.Page, &out.Page
+		*out = new(bool)
+		**out = **in
+	}
+	if in.Ticket != nil {
+		in, out := &in.Ticket, &out.Ticket
+		*out = new(bool)
+		**out = **in
+	}
+	if in.NotificationEmail != "" {
+		out.NotificationEmail = in.NotificationEmail
+	}
+	if in.SlackChannels != nil {
+		in, out := &in.SlackChannels, &out.SlackChannels
+		*out = make([]string, len(*in))
+		for i, elem := range *in {
+			(*out)[i] = elem
+		}
+	}
+	if in.Project != "" {
+		out.Project = in.Project
+	}
+	if in.Priority != "" {
+		out.Priority = in.Priority
+	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
+		for i, elem := range *in {
+			(*out)[i] = elem
+		}
+	}
+	if in.Components != nil {
+		in, out := &in.Components, &out.Components
+		*out = make([]string, len(*in))
+		for i, elem := range *in {
+			(*out)[i] = elem
+		}
+	}
+	if in.Description != "" {
+		out.Description = in.Description
+	}
+	if in.AlertAfter != "" {
+		out.AlertAfter = in.AlertAfter
+	}
+	if in.RealertEvery != "" {
+		out.CheckEvery = in.CheckEvery
+	}
+	if in.CheckEvery != "" {
+		out.CheckEvery = in.CheckEvery
+	}
+	if in.CheckOomEvents != nil {
+		in, out := &in.CheckOomEvents, &out.CheckOomEvents
+		*out = new(bool)
+		**out = **in
+	}
+}
+
+func (in *PaastaMonitoringSpec) DeepCopy() *PaastaMonitoringSpec {
+	if in == nil {
+		return nil
+	}
+	out := new(PaastaMonitoringSpec)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// GetSensuDefinition : Format the PaastaMonitoringSpec to be understood by yelp-sensu-runner
+func (spec *PaastaMonitoringSpec) GetSensuDefinition() []byte {
+	bytes, _ := json.Marshal(spec)
+	return bytes
+}

--- a/pkg/monitoringspec/monitoringspec_test.go
+++ b/pkg/monitoringspec/monitoringspec_test.go
@@ -1,0 +1,111 @@
+package monitoringspec
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestDeepCopy(t *testing.T) {
+	in := `{"team":"some-team","page":true,"tags":["some-tag"]}`
+	var spec PaastaMonitoringSpec
+	if err := json.Unmarshal([]byte(in), &spec); err != nil {
+		t.Errorf("Failed to unmarshal: %s", err)
+	}
+	spec2 := spec.DeepCopy()
+	spec.Team = "x"
+	if spec2.Team == "x" {
+		t.Errorf("Detected shallow copy of Team")
+	}
+	*spec.Page = false
+	if *spec2.Page == false {
+		t.Errorf("Detected shallow copy of Page")
+	}
+	spec.Tags = append(spec.Tags, "other-tag")
+	if len(spec2.Tags) != 1 {
+		t.Errorf("Detected shallow copy of Tags")
+	}
+	out, err := json.Marshal(spec2);
+	if err != nil {
+		t.Errorf("Failed to marshal: %s", err)
+	}
+	if string(out) != in {
+		t.Errorf("%s != %s", out, in)
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	team := "some-team"
+	page := true
+	tags := []string{"some-tag"}
+	jsonTags, _ := json.Marshal(tags)
+	in := fmt.Sprintf(`{"team":"%s","page":%t,"tags":%s}`,
+		team,
+		page,
+		string(jsonTags),
+	)
+	var spec PaastaMonitoringSpec
+	if err := json.Unmarshal([]byte(in), &spec); err != nil {
+		t.Errorf("Failed to unmarshal: %s", err)
+	}
+	if spec.Team != team {
+		t.Errorf("%s != %s", spec.Team, team)
+	}
+	if *spec.Page != page {
+		t.Errorf("%t != %t", *spec.Page, page)
+	}
+	if len(spec.Tags) != len(tags) {
+		t.Errorf("%s != %s", spec.Tags, tags)
+	}
+}
+
+func checkDeepCopy(t *testing.T, input string) {
+	in := []byte(input)
+	var spec PaastaMonitoringSpec
+	if err := json.Unmarshal(in, &spec); err != nil {
+		t.Errorf("Failed to unmarshal: %s", err)
+	}
+	spec2 := spec.DeepCopy()
+	out, err := json.Marshal(spec2)
+	if err != nil {
+		t.Errorf("Failed to marshal: %s", err)
+	}
+	if string(out) != input {
+		t.Errorf("%s != %s", out, in)
+	}
+}
+
+func TestEmptyDeepCopy(t *testing.T) {
+	checkDeepCopy(
+		t,
+		`{}`,
+	)
+}
+
+func TestOnlyTeamDeepCopy(t *testing.T) {
+	checkDeepCopy(
+		t,
+		`{"team":"some-team"}`,
+	)
+}
+
+func TestOnlyPageDeepCopy(t *testing.T) {
+	checkDeepCopy(
+		t,
+		`{"page":true}`,
+	)
+}
+
+func TestOnlyTagsDeepCopy(t *testing.T) {
+	checkDeepCopy(
+		t,
+		`{"tags":["some-tag"]}`,
+	)
+}
+
+func TestMultiDeepCopy(t *testing.T) {
+	checkDeepCopy(
+		t,
+		`{"team":"some-team","page":true,"tags":["some-tag"]}`,
+	)
+}


### PR DESCRIPTION
This follows the definition of monitoring.yaml in the PaaSTA
documentation.
https://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#monitoring-yaml

This commit will allow operators to understand the `monitoring` part of
custom resources submitted by PaaSTA.

-----

`bool` fields are pointers to be able to encode the fact that they not defined, it seems to be the Golang way to do it?