### PR TITLE
Add makefile option default

### DIFF
--- a/pkg/test_framework/harness.go
+++ b/pkg/test_framework/harness.go
@@ -173,12 +173,12 @@ func Parse(opts ...ParseOptionFn) *Options {
 
 	noCleanup := args.CmdLine.Bool("k8s.no-cleanup", args.NoCleanup, "should test cleanup after themselves")
 	verbose := args.CmdLine.Bool("k8s.log.verbose", false, "turn on more verbose logging")
-	makefile := args.CmdLine.String("k8s.makefile", args.Makefile, "makefile for cluster manipulation targets, relative to MakeDir")
-	makedir := args.CmdLine.String("k8s.makedir", args.MakeDir, "directory to makefile")
-	prefix := args.CmdLine.String("k8s.prefix", args.Prefix, "prefix for make cluster manipulation targets")
-	manifests := args.CmdLine.String("k8s.manifests", args.Manifests, "directory to K8s manifests")
+	makefile := args.CmdLine.String("k8s.makefile", args.Makefile, "makefile for glue targets, relative to makedir")
+	makedir := args.CmdLine.String("k8s.makedir", args.MakeDir, "directory to makefile, relative to test code")
+	prefix := args.CmdLine.String("k8s.prefix", args.Prefix, "prefix for glue targets in makefile")
+	manifests := args.CmdLine.String("k8s.manifests", args.Manifests, "directory to K8s manifests, relative to test code")
 	delay := args.CmdLine.Duration("k8s.op-delay", args.OperatorDelay, "operator start delay")
-	envAlways := args.CmdLine.Bool("k8s.env-always", args.EnvAlways, "always use environment variables from makefile")
+	envAlways := args.CmdLine.Bool("k8s.env-always", args.EnvAlways, "should always use environment variables from makefile")
 	_ = args.CmdLine.Parse(args.OsArgs)
 
 	// NOTE: We call "sanitize" functions both here and in Start(). This is to enable

--- a/pkg/test_framework/harness.go
+++ b/pkg/test_framework/harness.go
@@ -88,6 +88,7 @@ var Kube *Harness
 
 type ParseOptions struct {
 	MakeDir       string
+	Makefile      string
 	Manifests     string
 	Prefix        string
 	NoCleanup     bool
@@ -102,6 +103,12 @@ type ParseOptionFn func (a* ParseOptions)
 func DefaultMakeDir(makedir string) ParseOptionFn {
 	return func(a* ParseOptions) {
 		a.MakeDir = makedir
+	}
+}
+
+func DefaultMakefile(makefile string) ParseOptionFn {
+	return func(a* ParseOptions) {
+		a.Makefile = makefile
 	}
 }
 
@@ -151,6 +158,7 @@ func OverrideCmdLine(cmdline *flag.FlagSet) ParseOptionFn {
 func Parse(opts ...ParseOptionFn) *Options {
 	args := ParseOptions{
 		MakeDir:       "",
+		Makefile:      "Makefile",
 		Manifests:     "manifests",
 		Prefix:        "test",
 		NoCleanup:     false,
@@ -165,7 +173,7 @@ func Parse(opts ...ParseOptionFn) *Options {
 
 	noCleanup := args.CmdLine.Bool("k8s.no-cleanup", args.NoCleanup, "should test cleanup after themselves")
 	verbose := args.CmdLine.Bool("k8s.log.verbose", false, "turn on more verbose logging")
-	makefile := args.CmdLine.String("k8s.makefile", "Makefile", "makefile for cluster manipulation targets, relative to MakeDir")
+	makefile := args.CmdLine.String("k8s.makefile", args.Makefile, "makefile for cluster manipulation targets, relative to MakeDir")
 	makedir := args.CmdLine.String("k8s.makedir", args.MakeDir, "directory to makefile")
 	prefix := args.CmdLine.String("k8s.prefix", args.Prefix, "prefix for make cluster manipulation targets")
 	manifests := args.CmdLine.String("k8s.manifests", args.Manifests, "directory to K8s manifests")

--- a/pkg/test_framework/harness_test.go
+++ b/pkg/test_framework/harness_test.go
@@ -118,6 +118,7 @@ func TestParse(t *testing.T) {
 	// Test individual options (except verbose)
 	r1 := defs
 	r1.MakeDir = sanitizeMakeDir("foo")
+	r1.Makefile = "Bar"
 	r1.ManifestDirectory = "baz"
 	r1.Prefix = "fizz-"
 	r1.OperatorDelay = 5 * time.Second
@@ -127,6 +128,7 @@ func TestParse(t *testing.T) {
 	// Options can be set with Default... functions
 	o1 := *Parse(
 		DefaultMakeDir("foo"),
+		DefaultMakefile("Bar"),
 		DefaultManifests("baz"),
 		DefaultPrefix("fizz"),
 		DefaultOperatorDelay(5 * time.Second),
@@ -141,6 +143,7 @@ func TestParse(t *testing.T) {
 	o2 := *Parse(
 		OverrideOsArgs([]string{
 			"-k8s.makedir=foo",
+			"-k8s.makefile=Bar",
 			"-k8s.manifests=baz",
 			"-k8s.prefix=fizz",
 			"-k8s.op-delay=5s",
@@ -152,10 +155,11 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, r1, o2)
 
 	// Options can be set with Default... functions and overridden from command line
+	// Default "Makefile" is set for Makefile when no explicitly set
 	o3 := *Parse(
-		DefaultMakeDir("foo"),
-		DefaultManifests("baz"),
-		DefaultPrefix("fizz"),
+		DefaultMakeDir("bad"),
+		DefaultManifests("bad"),
+		DefaultPrefix("bad"),
 		DefaultOperatorDelay(5 * time.Second),
 		DefaultNoCleanup(),
 		DefaultEnvAlways(),


### PR DESCRIPTION
While writing documentation I realised that there is no functional option to set the default Makefile, this fixes it.

Also updated options help text to hopefully something slightly better.