### PR TITLE
Report paasta-tools version directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ GID:=$(shell id -g)
 GO_VERSION=1.12.7
 VERSION=0.0.7
 
-GOBUILD=GO111MODULE=on go build -ldflags="-X github.com/Yelp/paasta-tools-go/pkg/version.Version=$(VERSION)"
+GOBUILD=GO111MODULE=on go build -ldflags="\
+	-X github.com/Yelp/paasta-tools-go/pkg/version.Version=$(VERSION) \
+	-X github.com/Yelp/paasta-tools-go/pkg/version.PaastaVersion=$(PAASTA_VERSION)"
 
 .PHONY: cmd $(CMDS)
 

--- a/cmd/paasta/main.go
+++ b/cmd/paasta/main.go
@@ -142,11 +142,17 @@ func paasta() (int, error) {
 
 // os.Exit doesn't work well with defered calls
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "-version" {
-		fmt.Printf("paasta-tools-go version: %v\n", paastaversion.Version)
-		fmt.Printf("zipkin initializers: %v\n", strings.Join(paastazipkin.Initializers(), ", "))
-		fmt.Printf("go runtime: %v\n", runtime.Version())
-		os.Exit(0)
+	if len(os.Args) > 1 {
+		if os.Args[1] == "-version" {
+			fmt.Printf("paasta-tools-go version: %v\n", paastaversion.Version)
+			fmt.Printf("paasta-tools version: %v\n", paastaversion.PaastaVersion)
+			fmt.Printf("zipkin initializers: %v\n", strings.Join(paastazipkin.Initializers(), ", "))
+			fmt.Printf("go runtime: %v\n", runtime.Version())
+			os.Exit(0)
+		} else if os.Args[1] == "-V" {
+			fmt.Printf("paasta-tools %v\n", paastaversion.PaastaVersion)
+			os.Exit(0)
+		}
 	}
 
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,3 +2,6 @@ package version
 
 // Version of paasta-tools-go
 var Version = "HEAD"
+
+// PaastaVersion of python paasta-tools package
+var PaastaVersion = "HEAD"


### PR DESCRIPTION
paasta-go binary is built by paasta-tools packaging process, no need to invoke actual paasta python script to report version