### PR TITLE
Move IAM roles code into paasta-tools-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ UID:=$(shell id -u)
 GID:=$(shell id -g)
 
 GO_VERSION=1.12.7
-VERSION=0.0.12
+VERSION=0.0.13
 
 GOBUILD=GO111MODULE=on go build -ldflags="\
 	-X github.com/Yelp/paasta-tools-go/pkg/version.Version=$(VERSION) \

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-openapi/swag v0.19.5
 	github.com/go-openapi/validate v0.19.8
 	github.com/gogo/protobuf v1.2.1 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 h1:5ZkaAPbicIKTF2I64qf5Fh8Aa83Q/dnOafMYV0OMwjA=

--- a/pkg/iam_roles/iam_role.go
+++ b/pkg/iam_roles/iam_role.go
@@ -1,0 +1,134 @@
+package iam_role
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"regexp"
+	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IamRoleConfig : config for AWS IAM role settings for a paasta container
+type IamRoleConfig struct {
+	// +optional
+	IamRoleProvider *string `json:"iam_role_provider,omitempty"`
+	// +optional
+	IamRole *string `json:"iam_role,omitempty"`
+	// PAASTA-16919: remove everything related to fs_group when
+	// https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8 will be
+	// fixed.
+	// +optional
+	FsGroup *int64 `json:"fs_group,omitempty"`
+}
+
+var defaultIamRoleProvider = "kiam"
+var DefaultFsGroup int64 = 65534
+
+var serviceAccountRegex = regexp.MustCompile("[^0-9a-zA-Z]+")
+
+// SetIamRoleConfigDefaults: sets the default values for the AWS IAM role config
+func SetIamRoleConfigDefaults(iamRoleConfig *IamRoleConfig) {
+	if iamRoleConfig.IamRoleProvider == nil {
+		iamRoleConfig.IamRoleProvider = &defaultIamRoleProvider
+	}
+	if iamRoleConfig.FsGroup == nil {
+		iamRoleConfig.FsGroup = &DefaultFsGroup
+	}
+}
+
+// EnsureForIamRole: prepare AWS IAM role for use
+func EnsureForIamRole(ctx context.Context, client controllerruntimeclient.Client, namespace string, iamRoleConfig *IamRoleConfig) error {
+	// We need to create a service account only for "aws" provider
+	if iamRoleConfig.IamRoleProvider != nil && *iamRoleConfig.IamRoleProvider == "aws" {
+		glog.V(4).Infof("Ensuring service account in %s for iam_role %v exists", namespace, iamRoleConfig.IamRole)
+		if iamRoleConfig.IamRole == nil {
+			return fmt.Errorf("%s/%v: iam_role must be specified when iam_role_provider is set to 'aws'", namespace, iamRoleConfig.IamRole)
+		}
+
+		saName := getServiceAccountNameForIamRole(iamRoleConfig.IamRole)
+
+		// check if service account with this name+namespace already exists
+		glog.V(4).Infof("Looking for service account called %s in namespace %s", saName, namespace)
+		result := &corev1.ServiceAccount{}
+		err := client.Get(ctx,
+			types.NamespacedName{
+				Name:      saName,
+				Namespace: namespace,
+			},
+			result,
+		)
+
+		if err != nil {
+			glog.Errorf("Error while getting service account: %s", err)
+			if errors.IsNotFound(err) {
+				glog.Infof("Service account not found, creating it")
+				annotations := map[string]string{
+					"eks.amazonaws.com/role-arn": *iamRoleConfig.IamRole,
+				}
+				service_account := &corev1.ServiceAccount{
+					TypeMeta: v1.TypeMeta{},
+					ObjectMeta: v1.ObjectMeta{
+						Name:        saName,
+						Namespace:   namespace,
+						Annotations: annotations,
+					},
+					Secrets:                      nil,
+					ImagePullSecrets:             nil,
+					AutomountServiceAccountToken: nil,
+				}
+				err = client.Create(ctx, service_account)
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+			// some other error occurred
+			return err
+		}
+
+		// service account already exists so do nothing
+		glog.V(4).Info("Service account already exists")
+	}
+	return nil
+
+}
+
+// UpdatePodTemplateSpecForIamRole: updates provided pod template specs for kiam or AWS pod identity
+func UpdatePodTemplateSpecForIamRole(podTemplateSpec *corev1.PodTemplateSpec, iamRoleConfig *IamRoleConfig, defaultIamRole string) {
+	if iamRoleConfig.IamRoleProvider != nil && *iamRoleConfig.IamRoleProvider == "aws" {
+		var fsGroup *int64
+		if iamRoleConfig.FsGroup != nil {
+			fsGroup = iamRoleConfig.FsGroup
+		} else {
+			fsGroup = &DefaultFsGroup
+		}
+		podTemplateSpec.Spec.SecurityContext = &corev1.PodSecurityContext{FSGroup: fsGroup}
+
+		// generate "normalized" SA name from iamRole
+		podTemplateSpec.Spec.ServiceAccountName = getServiceAccountNameForIamRole(iamRoleConfig.IamRole)
+	} else {
+		var iamRole *string
+		if iamRoleConfig.IamRole != nil {
+			iamRole = iamRoleConfig.IamRole
+		} else {
+			iamRole = &defaultIamRole
+		}
+		if podTemplateSpec.Annotations == nil {
+			podTemplateSpec.Annotations = map[string]string{}
+		}
+		podTemplateSpec.Annotations["iam.amazonaws.com/role"] = *iamRole
+		podTemplateSpec.Spec.SecurityContext = &corev1.PodSecurityContext{}
+		podTemplateSpec.Spec.ServiceAccountName = ""
+	}
+	return
+}
+
+func getServiceAccountNameForIamRole(iamRole *string) (serviceAccountName string) {
+	serviceAccountName = serviceAccountRegex.ReplaceAllString(*iamRole, "-")
+	return "paasta--" + serviceAccountName
+}


### PR DESCRIPTION
Move IAM roles code from the Flink operator into paasta-tools-go and
make it generic, so it could be used for other operators as well.
At the moment there are no tests, as it's tested by tests from the Flink
operator.

Flink counterpart: https://github.yelpcorp.com/services/flink-operator/pull/37
Cassandra counterpart: https://github.yelpcorp.com/services/cassandra-operator/pull/49