### PR TITLE
Set default iam role provider to aws.

### DIFF
--- a/pkg/iam_roles/iam_role.go
+++ b/pkg/iam_roles/iam_role.go
@@ -25,7 +25,7 @@ type IamRoleConfig struct {
 	FsGroup *int64 `json:"fs_group,omitempty"`
 }
 
-var defaultIamRoleProvider = "kiam"
+var defaultIamRoleProvider = "aws"
 var DefaultFsGroup int64 = 65534
 
 var serviceAccountRegex = regexp.MustCompile("[^0-9a-zA-Z]+")


### PR DESCRIPTION
The `kiam` iam role provider will be soon deprecate, therefore, we set the `aws` provider as the default.