### PR TITLE
Add PAASTA_HOST as a default environment variable

### DIFF
--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -38,6 +38,14 @@ func GetDefaultPaastaKubernetesEnvironment() []corev1.EnvVar {
 				},
 			},
 		},
+		{
+			Name: "PAASTA_HOST",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
 	}
 	return defaultEnvironment
 }

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -42,6 +42,14 @@ func TestGetDefaultPaastaKubernetesEnvironment(test *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "PAASTA_HOST",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
 	}
 
 	if !reflect.DeepEqual(actual, fakeEnvironment) {


### PR DESCRIPTION
We do this in paasta-tools and certain scripts (e.g.,
is_pod_healthy_in_proxy) depend on this variable existing.