### PR TITLE
FLINK-4136: Add Comparator For KubeResourceQuantity

### DIFF
--- a/pkg/containerspec/containerspec.go
+++ b/pkg/containerspec/containerspec.go
@@ -46,6 +46,23 @@ func (n KubeResourceQuantity) copy() KubeResourceQuantity {
 	return KubeResourceQuantity(string(n))
 }
 
+func (n KubeResourceQuantity) Cmp(quantityToCompare KubeResourceQuantity) (int, error) {
+	quantityResource, err := resource.ParseQuantity(string(n))
+	if err != nil {
+		return 0, fmt.Errorf("error while parsing KubeResourceQuantity quantity '%s': %s", string(n), err)
+	}
+
+	quantityToCompareResource, err := resource.ParseQuantity(string(quantityToCompare))
+	if err != nil {
+		return 0, fmt.Errorf("error while parsing KubeResourceQuantity quantity '%s': %s", string(quantityToCompare), err)
+	}
+
+	// Cmp returns 0 if the quantityResource is equal to quantityToCompareResource
+	// -1 if the quantityResource is less than quantityToCompareResource
+	// 1 if the quantityResource is greater than quantityToCompareResource.
+	return quantityResource.Cmp(quantityToCompareResource), nil
+}
+
 // PaastaContainerSpec : Spec for any paasta container with basic fields and utilities
 type PaastaContainerSpec struct {
 	CPU         *KubeResourceQuantity `json:"cpus"`

--- a/pkg/containerspec/containerspec_test.go
+++ b/pkg/containerspec/containerspec_test.go
@@ -482,3 +482,53 @@ func TestImpliedEqualCPULimit(t *testing.T) {
 		},
 	)
 }
+
+
+func TestCmp_QuantityComparingToIsEqual_ReturnZero(t *testing.T) {
+	kubeResourceQuantity := KubeResourceQuantity("10")
+	kubeResourceQuantityToCompare := KubeResourceQuantity("10")
+
+	result, err := kubeResourceQuantity.Cmp(kubeResourceQuantityToCompare)
+	if err != nil {
+		t.Errorf("Unexpected error, %s", err.Error())
+	}
+
+	expected := 0
+
+	if !assert.Equal(t, expected, result) {
+		t.Fatalf("Not equal: Expected: %d, Actual: %d", expected, result)
+	}
+}
+
+func TestCmp_QuantityComparingToIsGreater_ReturnNegativeOne(t *testing.T) {
+	kubeResourceQuantity := KubeResourceQuantity("10")
+	kubeResourceQuantityToCompare := KubeResourceQuantity("20")
+
+	result, err := kubeResourceQuantity.Cmp(kubeResourceQuantityToCompare)
+	if err != nil {
+		t.Errorf("Unexpected error, %s", err.Error())
+	}
+
+	expected := -1
+
+	if !assert.Equal(t, expected, result) {
+		t.Fatalf("Not equal: Expected: %d, Actual: %d", expected, result)
+	}
+}
+
+func TestCmp_QuantityComparingToIsGreater_ReturnOne(t *testing.T) {
+	kubeResourceQuantity := KubeResourceQuantity("10")
+	kubeResourceQuantityToCompare := KubeResourceQuantity("5")
+
+	result, err := kubeResourceQuantity.Cmp(kubeResourceQuantityToCompare)
+	if err != nil {
+		t.Errorf("Unexpected error, %s", err.Error())
+	}
+
+	expected := 1
+
+	if !assert.Equal(t, expected, result) {
+		t.Fatalf("Not equal: Expected: %d, Actual: %d", expected, result)
+	}
+}
+


### PR DESCRIPTION
https://jira.yelpcorp.com/browse/FLINK-4136

Using KubeResourceQuantity in new go service flink-autotuner
https://github.yelpcorp.com/services/flink-autotuner

Implemented comparison in service, but thought made more sense to add this functionality to the paasta-tools-go for re-usability 