### PR TITLE
Add missing assert import to fix build

### DIFF
--- a/pkg/containerspec/containerspec_test.go
+++ b/pkg/containerspec/containerspec_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+    "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )


### PR DESCRIPTION
Not sure how we didn't notice this failure when these tests were written, but :shrug: