### PR TITLE
Use internal athens when building in yelpcorp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ GID:=$(shell id -g)
 GO_VERSION=1.12.7
 VERSION=0.0.20
 
+export GONOSUMDB=*.yelpcorp.com
+ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
+	export GOPROXY=http://athens.paasta-norcal-devc.yelp
+endif
+
 GOBUILD=CGO_ENABLED=0 GO111MODULE=on go build -ldflags="\
 	-X github.com/Yelp/paasta-tools-go/pkg/version.Version=$(VERSION) \
 	-X github.com/Yelp/paasta-tools-go/pkg/version.PaastaVersion=$(PAASTA_VERSION)"


### PR DESCRIPTION
We should probably refactor things so that we don't need an internal library in an open-source project - but until then, this should fix the internal build failure