### PR TITLE
add new common env paasta_instance_type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ UID:=$(shell id -u)
 GID:=$(shell id -g)
 
 GO_VERSION=1.12.7
-VERSION=0.0.20
+VERSION=0.0.21
 
 GOBUILD=CGO_ENABLED=0 GO111MODULE=on go build -ldflags="\
 	-X github.com/Yelp/paasta-tools-go/pkg/version.Version=$(VERSION) \

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -31,6 +31,14 @@ func GetDefaultPaastaKubernetesEnvironment() []corev1.EnvVar {
 			},
 		},
 		{
+			Name: "PAASTA_INSTANCE_TYPE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.labels['paasta.yelp.com/service']",
+				},
+			},
+		},
+		{
 			Name: "PAASTA_CLUSTER",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -35,6 +35,14 @@ func TestGetDefaultPaastaKubernetesEnvironment(test *testing.T) {
 			},
 		},
 		{
+			Name: "PAASTA_INSTANCE_TYPE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.labels['paasta.yelp.com/service']",
+				},
+			},
+		},
+		{
 			Name: "PAASTA_CLUSTER",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{


### PR DESCRIPTION
https://yelp.slack.com/archives/CAD7VU7GQ/p1723660526023579?thread_ts=1723050592.535799&cid=CAD7VU7GQ

After migrating to eks, we need a new envvar for the bill report. This is common for all custom operators and the value shall be equal to `paasta.yelp.com/service'

In nrtsearch live pod,
it's 
```
              paasta.yelp.com/service=nrtsearch
```