### PR TITLE
fix jwt service auth config loading

### DIFF
--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -220,3 +220,11 @@ func (s *Store) Load(key string, dst interface{}) (bool, error) {
 	}
 	return true, mapstructure.Decode(val, dst)
 }
+
+// AddHint inserts a new hint to find keys among config files
+func (s *Store) AddHint(key string, filename string) {
+	if s.Hints == nil {
+		s.Hints = map[string]string{}
+	}
+	s.Hints[key] = filename
+}

--- a/pkg/volumes/service_authentication_test.go
+++ b/pkg/volumes/service_authentication_test.go
@@ -36,12 +36,10 @@ func TestGetServiceAuthenticationTokenVolume(t *testing.T) {
 	}
 	mockJwtAuthConfig := &sync.Map{}
 	mockJwtAuthConfig.Store(
-		jwtServiceAuthConfigName,
-		jwtServiceAuthConfig{
-			TokenSettings: jwtServiceAuthTokenSettings{
-				Audience:      "foo.yelp.com",
-				ContainerPath: "/var/secret/serviceaccount/foo",
-			},
+		jwtServiceAuthConfigKey,
+		jwtServiceAuthTokenSettings{
+			Audience:      "foo.yelp.com",
+			ContainerPath: "/var/secret/serviceaccount/foo",
 		},
 	)
 	configReader := &configstore.Store{Data: mockJwtAuthConfig}


### PR DESCRIPTION
Should I have checked a bit better that config loading worked in the real world before shipping 
https://github.com/Yelp/paasta-tools-go/pull/96? Yes
Did I do it? No

Looking at other modules in this repo, I thought the key in `configStore.Load` was referring to a configuration filename, but it's instead a top-level key within the configuration files, which often corresponds to the filename, but not in the case of `jwt_service_auth`. To address the bug, I add to somehow get a hint added to the config store, so I created an helper method for that.

The other problem is that I didn't fully read the config-store implementation, and it uses `mapstructure` rather than the json unmarshaller, so the `jwtServiceAuthTokenSettings` struct was missing some annotations.

Now I did actually test config loading in the real world, and it works as expected.