### PR TITLE
stop setting DOCKER_HOST explicitly

### DIFF
--- a/pkg/test_framework/tests/Makefile
+++ b/pkg/test_framework/tests/Makefile
@@ -7,7 +7,9 @@ itest-env:
 itest-cluster-start:
 	docker build -t $${K3DIMAGE} .
 	rm -f $${CIDFILE}
-	docker container run -d --init --net=host --cidfile $${CIDFILE} -e CLUSTER=$${CLUSTER} -e DOCKER_HOST $${K3DIMAGE} /bin/sleep infinity
+# 	Making sure that we run using docker since k3d does not support podman
+# 	https://github.com/k3d-io/k3d/issues/1379
+	docker container run -d --init --net=host --cidfile $${CIDFILE} -e CLUSTER=$${CLUSTER} -e DOCKER_HOST=unix:///var/run/docker.sock -v /var/run/docker.sock:/var/run/docker.sock $${K3DIMAGE} /bin/sleep infinity
 	docker container exec $$(cat $${CIDFILE}) /bin/bash -c 'python3 port_reserve.py > port.txt && rm port_reserve.py'
 	docker container exec $$(cat $${CIDFILE}) /bin/bash -c 'k3d --trace cluster delete $${CLUSTER} &>/dev/null || echo -n'
 	docker container exec $$(cat $${CIDFILE}) /bin/bash -c 'k3d --trace cluster create $${CLUSTER} --api-port $$(cat port.txt) --wait --timeout 30s && rm port.txt'

--- a/pkg/test_framework/tests/Makefile
+++ b/pkg/test_framework/tests/Makefile
@@ -7,9 +7,7 @@ itest-env:
 itest-cluster-start:
 	docker build -t $${K3DIMAGE} .
 	rm -f $${CIDFILE}
-# 	Making sure that we run using docker since k3d does not support podman
-# 	https://github.com/k3d-io/k3d/issues/1379
-	docker container run -d --init --net=host --cidfile $${CIDFILE} -e CLUSTER=$${CLUSTER} -e DOCKER_HOST=unix:///var/run/docker.sock -v /var/run/docker.sock:/var/run/docker.sock $${K3DIMAGE} /bin/sleep infinity
+	docker container run -d --init --net=host --cidfile $${CIDFILE} -e CLUSTER=$${CLUSTER} -e DOCKER_HOST $${K3DIMAGE} /bin/sleep infinity
 	docker container exec $$(cat $${CIDFILE}) /bin/bash -c 'python3 port_reserve.py > port.txt && rm port_reserve.py'
 	docker container exec $$(cat $${CIDFILE}) /bin/bash -c 'k3d --trace cluster delete $${CLUSTER} &>/dev/null || echo -n'
 	docker container exec $$(cat $${CIDFILE}) /bin/bash -c 'k3d --trace cluster create $${CLUSTER} --api-port $$(cat port.txt) --wait --timeout 30s && rm port.txt'

--- a/pkg/test_framework/tests/Makefile
+++ b/pkg/test_framework/tests/Makefile
@@ -7,9 +7,14 @@ itest-env:
 itest-cluster-start:
 	docker build -t $${K3DIMAGE} .
 	rm -f $${CIDFILE}
+ifdef CI
+	# jenkins uses DOCKER_HOST, so make sure it's passed there
+	docker container run -d --init --net=host --cidfile $${CIDFILE} -e CLUSTER=$${CLUSTER} -e DOCKER_HOST $${K3DIMAGE} /bin/sleep infinity
+else
 # 	Making sure that we run using docker since k3d does not support podman
 # 	https://github.com/k3d-io/k3d/issues/1379
 	docker container run -d --init --net=host --cidfile $${CIDFILE} -e CLUSTER=$${CLUSTER} -e DOCKER_HOST=unix:///var/run/docker.sock -v /var/run/docker.sock:/var/run/docker.sock $${K3DIMAGE} /bin/sleep infinity
+endif
 	docker container exec $$(cat $${CIDFILE}) /bin/bash -c 'python3 port_reserve.py > port.txt && rm port_reserve.py'
 	docker container exec $$(cat $${CIDFILE}) /bin/bash -c 'k3d --trace cluster delete $${CLUSTER} &>/dev/null || echo -n'
 	docker container exec $$(cat $${CIDFILE}) /bin/bash -c 'k3d --trace cluster create $${CLUSTER} --api-port $$(cat port.txt) --wait --timeout 30s && rm port.txt'


### PR DESCRIPTION
Whatever bug that required this doesn't really matter since a) we disabled normal docker support on devboxes and b) we use docker-in-docker in jenkins, so this is plain wrong there.