### PR TITLE
bump GO_VERSION to match toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CMDS=$(wildcard cmd/*)
 UID:=$(shell id -u)
 GID:=$(shell id -g)
 
-GO_VERSION=1.12.7
+GO_VERSION=1.21.5
 VERSION=0.0.22
 
 ifeq ($(PAASTA_ENV),YELP)


### PR DESCRIPTION
This matches what's being set in the github workflow. I believe this will be required to make sure that the jenkins build actually works.