### PR TITLE
Add resolute Dockerfile for package build

### DIFF
--- a/yelp_package/resolute/Dockerfile
+++ b/yelp_package/resolute/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:resolute
+
+ARG GO_VERSION
+
+RUN apt-get -q update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -q install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        wget \
+        ruby \
+        ruby-dev \
+        rubygems \
+        build-essential \
+    && apt-get -q clean
+
+# Install go
+RUN wget http://godeb.s3.amazonaws.com/godeb-amd64.tar.gz && \
+    tar zxvf godeb-amd64.tar.gz && \
+    ./godeb download ${GO_VERSION} && \
+    dpkg -i go_${GO_VERSION}-godeb1_amd64.deb && \
+    rm godeb-amd64.tar.gz godeb go_${GO_VERSION}-godeb1_amd64.deb
+
+RUN gem install fpm
+
+WORKDIR /work


### PR DESCRIPTION
Adds `yelp_package/resolute/Dockerfile` so the resolute platform build
can find its build container (same as jammy but with `FROM ubuntu:resolute`).

Without this, `make docker_build_resolute` fails with:
```
/bin/sh: 1: cd: can't cd to ./yelp_package/resolute
```

NETRES-639